### PR TITLE
feat: modernize front page with animations

### DIFF
--- a/src/components/CvSection.tsx
+++ b/src/components/CvSection.tsx
@@ -1,6 +1,6 @@
 export default function CvSection() {
   return (
-    <section className="px-4 py-16">
+    <section className="px-4 py-16 animate-fadeInUp">
       <div className="max-w-3xl mx-auto text-center">
         <h2 className="text-3xl font-semibold">CV</h2>
         <p className="mt-4 text-gray-700">
@@ -8,7 +8,7 @@ export default function CvSection() {
         </p>
         <a
           href="/cv.pdf"
-          className="inline-block px-6 py-3 mt-6 text-white bg-blue-600 rounded hover:bg-blue-700"
+          className="inline-block px-6 py-3 mt-6 text-white transition-transform bg-blue-600 rounded hover:bg-blue-700 hover:scale-105"
         >
           Download CV
         </a>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="px-4 py-8 text-gray-200 bg-gray-900">
+    <footer className="px-4 py-8 text-gray-200 bg-gray-900 animate-fadeInUp">
       <div className="flex flex-col items-center max-w-5xl mx-auto space-y-4 md:flex-row md:justify-between md:space-y-0">
         <span>© {new Date().getFullYear()} Xinudesign</span>
         <div className="flex items-center space-x-4">
@@ -12,7 +12,7 @@ export default function Footer() {
           </a>
           <a
             href="#contact"
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700"
+            className="px-4 py-2 text-sm font-medium text-white transition-transform bg-blue-600 rounded hover:bg-blue-700 hover:scale-105"
           >
             Contact
           </a>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,13 +1,31 @@
 export default function Hero() {
   return (
-    <section className="flex flex-col items-center justify-center min-h-screen px-4 text-center bg-gray-50">
-      <h1 className="text-4xl font-bold md:text-6xl">Michaël Redant</h1>
-      <p className="mt-4 text-xl md:text-2xl">
-        Freelance marketeer & webdeveloper
-      </p>
-      <p className="max-w-xl mt-2 text-gray-600 md:text-lg">
-        Strategische marketing en webontwikkeling met focus op resultaat.
-      </p>
+    <section className="relative flex items-center justify-center min-h-screen overflow-hidden">
+      <video
+        src="/assets/video/ai_video.mp4"
+        className="absolute inset-0 object-cover w-full h-full"
+        autoPlay
+        loop
+        muted
+      />
+      <div className="absolute inset-0 bg-black/40" />
+      <div className="relative z-10 flex flex-col items-center px-4 text-center text-white animate-fadeInUp">
+        <img
+          src="/assets/img/profile.jpg"
+          alt="Michaël Redant"
+          className="w-32 h-32 mb-6 rounded-full shadow-lg animate-float"
+        />
+        <h1 className="text-4xl font-bold md:text-6xl">Michaël Redant</h1>
+        <p className="mt-4 text-xl md:text-2xl">
+          Freelance marketeer &amp; webdeveloper
+        </p>
+        <a
+          href="#contact"
+          className="px-8 py-3 mt-6 text-lg font-medium text-white transition-transform bg-blue-600 rounded-full hover:scale-105"
+        >
+          Let&apos;s Talk
+        </a>
+      </div>
     </section>
   );
 }

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -1,6 +1,6 @@
 export default function Intro() {
   return (
-    <section className="max-w-3xl px-4 py-16 mx-auto">
+    <section className="max-w-3xl px-4 py-16 mx-auto text-center animate-fadeInUp">
       <h2 className="text-3xl font-semibold">Xinudesign in een notendop</h2>
       <p className="mt-4 text-gray-700">
         Focus op SEO, marketing, webdesign en strategie. Placeholdertekst om de

--- a/src/components/NewSection.tsx
+++ b/src/components/NewSection.tsx
@@ -1,6 +1,6 @@
 export default function NewSection() {
   return (
-    <section className="max-w-3xl px-4 py-16 mx-auto bg-gray-100 rounded-lg">
+    <section className="max-w-3xl px-4 py-16 mx-auto text-center bg-gray-100 rounded-lg animate-fadeInUp">
       <h2 className="text-3xl font-semibold">Nieuw bij Xinudesign</h2>
       <p className="mt-4 text-gray-700">
         Introductie van <span className="font-medium">Vibe Coding</span>: een

--- a/src/components/ProjectSection.tsx
+++ b/src/components/ProjectSection.tsx
@@ -1,12 +1,12 @@
 export default function ProjectSection() {
   return (
-    <section className="px-4 py-16 bg-gray-50">
+    <section className="px-4 py-16 bg-gray-50 animate-fadeInUp">
       <div className="max-w-3xl mx-auto text-center">
         <h2 className="text-3xl font-semibold">Projecten</h2>
         <div className="mt-8">
           <a
             href="https://personavault.xinudesign.be"
-            className="block p-6 transition border rounded-lg hover:bg-white"
+            className="block p-6 transition-transform border rounded-lg hover:scale-105 hover:bg-white"
           >
             <h3 className="text-xl font-medium">Persona Vault</h3>
             <p className="mt-2 text-gray-700">

--- a/src/components/Specializations.tsx
+++ b/src/components/Specializations.tsx
@@ -2,29 +2,37 @@ const items = [
   {
     title: "Digitale marketing",
     description: "SEO, automation, advertising",
+    icon: "/assets/logos/google-analytics.svg",
   },
   {
     title: "Webontwikkeling",
     description: "React, WordPress, Laravel",
+    icon: "/assets/logos/laravel.svg",
   },
   {
     title: "AI-toepassingen",
     description: "Eigen GPT\u2019s, data-gedreven campagnes",
+    icon: "/assets/logos/power-bi.svg",
   },
   {
     title: "3D-printing",
     description: "X3DPrints als subdienst",
+    icon: "/assets/logos/autodesk.svg",
   },
 ];
 
 export default function Specializations() {
   return (
-    <section className="px-4 py-16">
+    <section className="px-4 py-16 bg-white animate-fadeInUp">
       <div className="max-w-5xl mx-auto">
-        <h2 className="text-3xl font-semibold">Specialisaties</h2>
+        <h2 className="text-3xl font-semibold text-center">Specialisaties</h2>
         <div className="grid gap-6 mt-8 md:grid-cols-2">
           {items.map((item) => (
-            <div key={item.title} className="p-6 border rounded-lg">
+            <div
+              key={item.title}
+              className="p-6 text-center transition-transform border rounded-lg hover:-translate-y-1"
+            >
+              <img src={item.icon} alt="" className="w-12 h-12 mx-auto mb-4" />
               <h3 className="text-xl font-medium">{item.title}</h3>
               <p className="mt-2 text-gray-700">{item.description}</p>
             </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,22 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        fadeInUp: {
+          "0%": { opacity: 0, transform: "translateY(20px)" },
+          "100%": { opacity: 1, transform: "translateY(0)" },
+        },
+        float: {
+          "0%, 100%": { transform: "translateY(-3%)" },
+          "50%": { transform: "translateY(3%)" },
+        },
+      },
+      animation: {
+        fadeInUp: "fadeInUp 0.6s ease-out forwards",
+        float: "float 4s ease-in-out infinite",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- redesign hero with background video, floating profile image and call-to-action
- animate sections and skill cards for a modern feel
- define custom Tailwind keyframes for fade-in and float effects

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689212db904483329620f1ef9bd83cb9