### PR TITLE
Add scrolling logo marquee and expand homepage section spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import Hero from "./components/Hero";
 import Intro from "./components/Intro";
+import ToolsMarquee from "./components/ToolsMarquee";
 import NewSection from "./components/NewSection";
 import Specializations from "./components/Specializations";
 import ProjectSection from "./components/ProjectSection";
@@ -11,6 +12,7 @@ export default function App() {
     <>
       <Hero />
       <Intro />
+      <ToolsMarquee />
       <NewSection />
       <Specializations />
       <ProjectSection />

--- a/src/components/CvSection.tsx
+++ b/src/components/CvSection.tsx
@@ -1,6 +1,6 @@
 export default function CvSection() {
   return (
-    <section className="px-4 py-16 animate-fadeInUp">
+    <section className="px-4 py-24 bg-white animate-fadeInUp">
       <div className="max-w-3xl mx-auto text-center">
         <h2 className="text-3xl font-semibold">CV</h2>
         <p className="mt-4 text-gray-700">

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -23,9 +23,7 @@ const services = [
 
 export default function Intro() {
   return (
-
-    <section className="px-4 py-16 mx-auto text-center max-w-5xl animate-fadeInUp">
-
+    <section className="px-4 py-24 mx-auto text-center bg-white max-w-5xl animate-fadeInUp">
       <h2 className="text-3xl font-semibold">Xinudesign in een notendop</h2>
       <p className="mt-4 text-gray-700">
         Van strategie tot uitvoering: alle digitale diensten onder \u00e9\u00e9n

--- a/src/components/NewSection.tsx
+++ b/src/components/NewSection.tsx
@@ -1,6 +1,6 @@
 export default function NewSection() {
   return (
-    <section className="max-w-3xl px-4 py-16 mx-auto text-center bg-gray-100 rounded-lg animate-fadeInUp">
+    <section className="max-w-3xl px-4 py-24 mx-auto text-center bg-white rounded-lg animate-fadeInUp">
       <h2 className="text-3xl font-semibold">Nieuw bij Xinudesign</h2>
       <p className="mt-4 text-gray-700">
         Introductie van <span className="font-medium">Vibe Coding</span>: een

--- a/src/components/ProjectSection.tsx
+++ b/src/components/ProjectSection.tsx
@@ -1,6 +1,6 @@
 export default function ProjectSection() {
   return (
-    <section className="px-4 py-16 bg-gray-50 animate-fadeInUp">
+    <section className="px-4 py-24 bg-white animate-fadeInUp">
       <div className="max-w-3xl mx-auto text-center">
         <h2 className="text-3xl font-semibold">Projecten</h2>
         <div className="mt-8">

--- a/src/components/Specializations.tsx
+++ b/src/components/Specializations.tsx
@@ -23,7 +23,7 @@ const items = [
 
 export default function Specializations() {
   return (
-    <section className="px-4 py-16 bg-white animate-fadeInUp">
+    <section className="px-4 py-24 bg-white animate-fadeInUp">
       <div className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-semibold text-center">Specialisaties</h2>
         <div className="grid gap-6 mt-8 md:grid-cols-2">

--- a/src/components/ToolsMarquee.tsx
+++ b/src/components/ToolsMarquee.tsx
@@ -1,0 +1,38 @@
+const logos = [
+  "/assets/logos/adobe.svg",
+  "/assets/logos/adobe-after-effects.svg",
+  "/assets/logos/adobe-illustrator.svg",
+  "/assets/logos/adobe-photoshop.svg",
+  "/assets/logos/autodesk.svg",
+  "/assets/logos/canva.svg",
+  "/assets/logos/css.svg",
+  "/assets/logos/google-ads.svg",
+  "/assets/logos/google-analytics.svg",
+  "/assets/logos/google-gke.svg",
+  "/assets/logos/indesign.svg",
+  "/assets/logos/laravel.svg",
+  "/assets/logos/link-intact.svg",
+  "/assets/logos/openai.svg",
+  "/assets/logos/php.svg",
+  "/assets/logos/power-bi.svg",
+  "/assets/logos/shopify.svg",
+  "/assets/logos/sql-database-generic.svg",
+  "/assets/logos/visual-studio-code.svg",
+  "/assets/logos/vue.svg",
+  "/assets/logos/windows.svg",
+  "/assets/logos/wix.svg",
+];
+
+export default function ToolsMarquee() {
+  return (
+    <section className="py-24 bg-white animate-fadeInUp">
+      <div className="overflow-hidden">
+        <div className="flex items-center gap-8 animate-marquee w-max">
+          {logos.concat(logos).map((logo, index) => (
+            <img key={index} src={logo} alt="" className="h-12 w-auto" />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,10 +12,15 @@ export default {
           "0%, 100%": { transform: "translateY(-3%)" },
           "50%": { transform: "translateY(3%)" },
         },
+        marquee: {
+          "0%": { transform: "translateX(0)" },
+          "100%": { transform: "translateX(-50%)" },
+        },
       },
       animation: {
         fadeInUp: "fadeInUp 0.6s ease-out forwards",
         float: "float 4s ease-in-out infinite",
+        marquee: "marquee 30s linear infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary
- add ToolsMarquee component with horizontally scrolling software logos
- increase vertical spacing and use white backgrounds across homepage sections
- define marquee animation in Tailwind configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6892f39f44f48332bf67a0af613b0b02