### PR TITLE
feat: improve tools marquee hover interactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ src/
 ```
 
 ## Stylingrichtlijnen (Tailwind)
+
 Gebruik utility-first benadering (geen externe CSS tenzij nodig)
 
 Lange klassenreeksen? Gebruik clsx() of classnames
@@ -38,10 +39,12 @@ Herbruikbare UI? → <Button variant="primary" /> componentiseren
 
 Tailwind componentklassen definiëren via @layer components in tailwind.config.js
 
-##  Liquid Glass-stijl voor modals/popups (Apple-style)
+## Liquid Glass-stijl voor modals/popups (Apple-style)
+
 Gebruik dit visuele effect voor overlays zoals modals, sheets en popups.
 
-##  Voorbeeldimplementatie (React + Tailwind)
+## Voorbeeldimplementatie (React + Tailwind)
+
 ```tsx
 Kopiëren
 Bewerken
@@ -52,7 +55,9 @@ Bewerken
   </div>
 </div>
 ```
-##  Designrichtlijnen
+
+## Designrichtlijnen
+
 bg-white/10 + backdrop-blur-2xl voor glasachtig effect
 
 rounded-2xl, border-white/20, shadow-xl voor diepte
@@ -64,6 +69,7 @@ Donkere modus via dark:bg-black/30
 Sluitknop positioneren met absolute top-2 right-2
 
 ## Gebruik voor:
+
 <Modal />
 
 <Popup />
@@ -73,6 +79,7 @@ Sluitknop positioneren met absolute top-2 right-2
 <Overlay />
 
 ## Componentconventies
+
 Component in eigen map (indien complex):
 
 ```txt
@@ -83,6 +90,7 @@ Bewerken
 └── MyComponent.module.ts
 Componentnaam = PascalCase
 ```
+
 Functies schrijven als functionele componenten met typing:
 
 ```tsx
@@ -95,6 +103,7 @@ Gebruik default exports tenzij meerdere exports logisch zijn
 ```
 
 ## TypeScript conventies
+
 Gebruik interface voor props, type voor unions
 
 Globale types in src/types/
@@ -103,17 +112,18 @@ Vermijd Partial, any, as tenzij goed onderbouwd
 
 Alles expliciet typiseren
 
-
 ## Pre-commit checks
+
 bash
 Kopiëren
 Bewerken
-npm run format     # Code formatteren
-npm run lint       # Linting controleren
-npm run build      # Build valideren
-npm run dev        # (Optioneel) lokaal previewen
+npm run format # Code formatteren
+npm run lint # Linting controleren
+npm run build # Build valideren
+npm run dev # (Optioneel) lokaal previewen
 
 ## Deploymentrichtlijnen
+
 Dev-server: npm run dev
 
 Build: npm run build
@@ -123,6 +133,7 @@ Deploy target: Vercel (auto via GitHub)
 Gevoelige info in .env.local (niet commiten)
 
 ## Naming & Consistency
+
 Bestandnamen: PascalCase
 
 Assets: kebab-case (bijv. hero-bg.jpg)
@@ -134,7 +145,8 @@ Routes/URLs: kebab-case (/about-us, /diensten/webdesign)
 Taal: code in Engels, tekstinhoud Belgisch, Vlaams, menselijk klinkend
 
 ## Documentatie & Changelogs
-Gebruik /** ... */ JSDoc voor complexe functies
+
+Gebruik `/** ... */` JSDoc voor complexe functies
 
 Changelog bijhouden in /CHANGELOG.md of via GitHub Releases
 

--- a/prompts.md
+++ b/prompts.md
@@ -7,52 +7,55 @@ Slimme, herbruikbare prompts voor ChatGPT Codex of Copilot Chat. Gericht op snel
 ## 🧩 1. Componentprompts
 
 ### Nieuwe component
+
 Maak een stateless functional component in React met TypeScript en Tailwind CSS. Gebruik props en geef duidelijke types. Zet de component in src/components/ComponentNaam.tsx.
 
-
 ### Formuliercomponent met validatie
+
 Genereer een ContactForm.tsx component in React met Tailwind styling. Velden: naam, e-mail, bericht. Voeg validatie toe: verplicht, correcte e-mail, minimumlengte. Typiseer props en state.
 
-
 ### Pagina met layout
-Maak een pagina Projecten.tsx met 2-koloms grid, max-w-screen-xl, padding op mobiele weergave. Responsief via Tailwind, met headings en cards.
 
+Maak een pagina Projecten.tsx met 2-koloms grid, max-w-screen-xl, padding op mobiele weergave. Responsief via Tailwind, met headings en cards.
 
 ---
 
 ## 📚 4. Functiedocumentatie & Uitleg
 
 ### Documenteer helperfunctie
+
 Voorzie deze TypeScript functie van JSDoc-commentaar. Leg de input, output en werking uit in 2 zinnen. Verbeter de typing waar nodig.
 
-
 ### Verbeter en leg uit
-Bekijk deze functie op bugs en optimalisatie. Refactor en geef beknopte uitleg waarom je dat doet.
 
+Bekijk deze functie op bugs en optimalisatie. Refactor en geef beknopte uitleg waarom je dat doet.
 
 ---
 
 ## 🎨 6. Tailwind Prompts
 
 ### Grid met interactieve kaarten
+
 Genereer een grid van 3 Tailwind-kaarten in React. Elke kaart heeft afbeelding, titel, beschrijving en knop. Gebruik shadow-md, rounded-lg, hover:scale-105 en transition-all.
 
-
 ### Donkere modus layout
-Bouw een layoutcomponent (BaseLayout.tsx) met ondersteuning voor dark:-klassen in Tailwind. Voeg een toggle toe om tussen light en dark te switchen. Gebruik useState of localStorage.
 
+Bouw een layoutcomponent (BaseLayout.tsx) met ondersteuning voor dark:-klassen in Tailwind. Voeg een toggle toe om tussen light en dark te switchen. Gebruik useState of localStorage.
 
 ---
 
 ## Bonus
- ### Site roadmap genereren
- Genereer een gestructureerde roadmap van pagina’s en componenten voor een website van een freelance webdesigner in React. Pagina’s: Home, Diensten, Projecten, Over, Contact, Blog. Voeg subcomponenten toe zoals: Hero, Testimonials, ProjectCard, BlogItem.
 
- ---
+### Site roadmap genereren
+
+Genereer een gestructureerde roadmap van pagina’s en componenten voor een website van een freelance webdesigner in React. Pagina’s: Home, Diensten, Projecten, Over, Contact, Blog. Voeg subcomponenten toe zoals: Hero, Testimonials, ProjectCard, BlogItem.
+
+---
 
 ## 🏷️ 7. GPT-component logging
 
 ### Component taggen bij output
+
 ```tsx
 // [🧠 GPT-generated - YYYY-MM-DD - ComponentOmschrijving]
 // ⚠️ Handmatig controleren op Tailwind-styling en types
@@ -64,3 +67,4 @@ Voorbeeld:
 ---
 
 
+```

--- a/src/components/ToolsMarquee.tsx
+++ b/src/components/ToolsMarquee.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import GlassPane from "./GlassPane";
 
 interface Tool {
@@ -30,16 +31,27 @@ const tools: Tool[] = [
 ];
 
 export default function ToolsMarquee() {
+  const [isPaused, setIsPaused] = useState(false);
+
   return (
     <section className="py-24 bg-white animate-fadeInUp">
       <div className="overflow-x-hidden">
-        <div className="flex items-center gap-8 animate-marquee w-max">
+        <div
+          className="flex items-center gap-8 animate-marquee w-max"
+          style={{ animationPlayState: isPaused ? "paused" : "running" }}
+        >
           {tools.concat(tools).map((tool, index) => (
             <div
               key={`${tool.src}-${index}`}
-              className="relative group flex items-center"
+              className="relative group flex items-center cursor-pointer"
+              onMouseEnter={() => setIsPaused(true)}
+              onMouseLeave={() => setIsPaused(false)}
             >
-              <img src={tool.src} alt={tool.name} className="h-12 w-auto" />
+              <img
+                src={tool.src}
+                alt={tool.name}
+                className="h-12 w-auto transition-transform duration-300 group-hover:scale-110"
+              />
               <GlassPane className="absolute bottom-full left-1/2 mb-2 -translate-x-1/2 -translate-y-1 px-3 py-1 text-xs text-gray-800 whitespace-nowrap opacity-0 scale-95 group-hover:opacity-100 group-hover:translate-y-0 group-hover:scale-100 transition-all duration-200 ease-out pointer-events-none">
                 {tool.name}
               </GlassPane>


### PR DESCRIPTION
## Summary
- pause marquee scroll and enlarge tool logos on hover
- format documentation

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68930dbe3d148332889e292a0b5fb689