### PR TITLE
Modern intro with social links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,12 +3,33 @@ export default function Footer() {
     <footer className="px-4 py-8 text-gray-200 bg-gray-900 animate-fadeInUp">
       <div className="flex flex-col items-center max-w-5xl mx-auto space-y-4 md:flex-row md:justify-between md:space-y-0">
         <span>© {new Date().getFullYear()} Xinudesign</span>
-        <div className="flex items-center space-x-4">
+        <div className="flex flex-wrap items-center justify-center gap-4 md:justify-end">
           <a href="mailto:info@xinudesign.be" className="hover:underline">
             info@xinudesign.be
           </a>
-          <a href="https://linkedin.com" className="hover:underline">
+          <a
+            href="https://www.linkedin.com/in/michael-redant"
+            className="hover:underline"
+          >
             LinkedIn
+          </a>
+          <a
+            href="https://github.com/michael-redant"
+            className="hover:underline"
+          >
+            GitHub
+          </a>
+          <a
+            href="https://www.instagram.com/michael-redant"
+            className="hover:underline"
+          >
+            Instagram
+          </a>
+          <a
+            href="https://www.facebook.com/michael-redant"
+            className="hover:underline"
+          >
+            Facebook
           </a>
           <a
             href="#contact"

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -1,43 +1,125 @@
-const services = [
+import React from "react";
+
+interface Activity {
+  id: number;
+  name: string;
+  description: string;
+}
+
+const activities: Activity[] = [
   {
-    title: "Webdesign & development",
-    description: "Responsive sites, webshops en op maat gemaakte apps",
-    icon: "/assets/logos/css.svg",
+    id: 1,
+    name: "Content Creatie",
+    description:
+      "Creëer efficiënte en creatieve inhoud met behulp van AI-tools zoals GPT en DALL-E.",
   },
   {
-    title: "SEO & marketing",
-    description: "Zoekmachineoptimalisatie, campagnes en analytics",
-    icon: "/assets/logos/google-analytics.svg",
+    id: 2,
+    name: "Automatisering",
+    description:
+      "Automatiseer je campagnes en workflows met slimme AI-integraties.",
   },
   {
-    title: "Branding & design",
-    description: "Logo's, huisstijlen en visuele content",
-    icon: "/assets/logos/adobe-illustrator.svg",
+    id: 3,
+    name: "SEO / SEM",
+    description:
+      "Boost je online zichtbaarheid met AI-gestuurde analyses en optimalisaties.",
   },
   {
-    title: "Training & support",
-    description: "Workshops en begeleiding voor teams",
-    icon: "/assets/logos/openai.svg",
+    id: 4,
+    name: "Workshops en Trainingen",
+    description:
+      "Leer hoe je AI-tools kunt inzetten voor marketing en contentcreatie.",
+  },
+  {
+    id: 5,
+    name: "Data-gedreven Strategieën",
+    description:
+      "Transformeer data in actie met visuele inzichten en strategische plannen.",
+  },
+  {
+    id: 6,
+    name: "Webdesign",
+    description:
+      "Beheer eenvoudig je website met een krachtig Content Management Systeem.",
+  },
+  {
+    id: 7,
+    name: "Webdevelopment",
+    description:
+      "Bouw krachtige, schaalbare webapplicaties met moderne technologieën.",
+  },
+  {
+    id: 8,
+    name: "UI/UX",
+    description:
+      "Ontwerp intuïtieve en aantrekkelijke gebruikerservaringen met Figma.",
+  },
+  {
+    id: 9,
+    name: "Lokale SEO",
+    description:
+      "Verhoog je zichtbaarheid met geoptimaliseerde lokale landingspagina's.",
+  },
+];
+
+const socialLinks = [
+  {
+    href: "https://www.linkedin.com/in/michael-redant",
+    label: "LinkedIn",
+    abbreviation: "IN",
+  },
+  {
+    href: "https://github.com/michael-redant",
+    label: "GitHub",
+    abbreviation: "GH",
+  },
+  {
+    href: "https://www.instagram.com/michael-redant",
+    label: "Instagram",
+    abbreviation: "IG",
+  },
+  {
+    href: "https://www.facebook.com/michael-redant",
+    label: "Facebook",
+    abbreviation: "FB",
   },
 ];
 
 export default function Intro() {
   return (
     <section className="px-4 py-24 mx-auto text-center bg-white max-w-5xl animate-fadeInUp">
+      <img
+        src="/assets/xinu.png"
+        alt="Xinudesign"
+        className="w-24 h-24 mx-auto mb-6"
+      />
       <h2 className="text-3xl font-semibold">Xinudesign in een notendop</h2>
       <p className="mt-4 text-gray-700">
-        Van strategie tot uitvoering: alle digitale diensten onder \u00e9\u00e9n
-        dak.
+        Van strategie tot uitvoering: alle digitale diensten onder één dak.
       </p>
-      <div className="grid gap-6 mt-12 md:grid-cols-2">
-        {services.map((service) => (
+      <div className="flex justify-center mt-6 space-x-3">
+        {socialLinks.map((link) => (
+          <a
+            key={link.href}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center w-10 h-10 text-xs font-bold text-gray-700 bg-white border rounded-full hover:bg-gray-100"
+          >
+            <span className="sr-only">{link.label}</span>
+            {link.abbreviation}
+          </a>
+        ))}
+      </div>
+      <div className="grid gap-6 mt-12 md:grid-cols-2 lg:grid-cols-3">
+        {activities.map((activity) => (
           <div
-            key={service.title}
+            key={activity.id}
             className="p-6 transition-transform bg-white border rounded-lg hover:-translate-y-1"
           >
-            <img src={service.icon} alt="" className="w-12 h-12 mx-auto mb-4" />
-            <h3 className="text-xl font-medium">{service.title}</h3>
-            <p className="mt-2 text-gray-700">{service.description}</p>
+            <h3 className="text-xl font-medium">{activity.name}</h3>
+            <p className="mt-2 text-gray-700">{activity.description}</p>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- replace service cards with activities and show xinu logo
- add social buttons for LinkedIn, GitHub, Instagram and Facebook
- expose same social links in the footer

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68931d010a308332bd8716c8e88e4ac6