### PR TITLE
Modern intro with social links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "xinudesign",
       "version": "0.0.0",
       "dependencies": {
+        "aos": "^2.3.4",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1874,6 +1876,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aos": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/aos/-/aos-2.3.4.tgz",
+      "integrity": "sha512-zh/ahtR2yME4I51z8IttIt4lC1Nw0ktsFtmeDzID1m9naJnWXhCoARaCgNOGXb5CLy3zm+wqmRAEgMYB5E2HUw==",
+      "license": "MIT",
+      "dependencies": {
+        "classlist-polyfill": "^1.0.3",
+        "lodash.debounce": "^4.0.6",
+        "lodash.throttle": "^4.0.1"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -2334,6 +2347,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classlist-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ==",
+      "license": "Unlicense"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -4356,11 +4375,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -5085,6 +5116,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "format:write": "prettier --write ."
   },
   "dependencies": {
+    "aos": "^2.3.4",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from "react";
+import AOS from "aos";
+import "aos/dist/aos.css";
 import Hero from "./components/Hero";
 import Intro from "./components/Intro";
 import ToolsMarquee from "./components/ToolsMarquee";
@@ -8,6 +11,10 @@ import CvSection from "./components/CvSection";
 import Footer from "./components/Footer";
 
 export default function App() {
+  useEffect(() => {
+    AOS.init({ duration: 600, once: true });
+  }, []);
+
   return (
     <>
       <Hero />

--- a/src/components/CvSection.tsx
+++ b/src/components/CvSection.tsx
@@ -1,6 +1,6 @@
 export default function CvSection() {
   return (
-    <section className="px-4 py-24 bg-white animate-fadeInUp">
+    <section className="px-4 py-24 bg-white" data-aos="fade-up">
       <div className="max-w-3xl mx-auto text-center">
         <h2 className="text-3xl font-semibold">CV</h2>
         <p className="mt-4 text-gray-700">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,15 +1,53 @@
+import { FaLinkedin, FaGithub, FaInstagram, FaFacebook } from "react-icons/fa";
+
+const socialLinks = [
+  {
+    name: "LinkedIn",
+    icon: FaLinkedin,
+    url: "https://www.linkedin.com/in/michael-redant",
+    color: "text-primary hover:text-hover",
+  },
+  {
+    name: "GitHub",
+    icon: FaGithub,
+    url: "https://github.com/michael-redant",
+    color: "text-text hover:text-hover",
+  },
+  {
+    name: "Instagram",
+    icon: FaInstagram,
+    url: "https://www.instagram.com/michael-redant",
+    color: "text-secondary hover:text-hover",
+  },
+  {
+    name: "Facebook",
+    icon: FaFacebook,
+    url: "https://www.facebook.com/michael-redant",
+    color: "text-blue-700 hover:text-blue-900",
+  },
+];
+
 export default function Footer() {
   return (
-    <footer className="px-4 py-8 text-gray-200 bg-gray-900 animate-fadeInUp">
+    <footer className="px-4 py-8 text-gray-200 bg-gray-900" data-aos="fade-up">
       <div className="flex flex-col items-center max-w-5xl mx-auto space-y-4 md:flex-row md:justify-between md:space-y-0">
         <span>© {new Date().getFullYear()} Xinudesign</span>
-        <div className="flex items-center space-x-4">
+        <div className="flex flex-wrap items-center justify-center gap-4 md:justify-end">
           <a href="mailto:info@xinudesign.be" className="hover:underline">
             info@xinudesign.be
           </a>
-          <a href="https://linkedin.com" className="hover:underline">
-            LinkedIn
-          </a>
+          {socialLinks.map(({ name, icon: Icon, url, color }) => (
+            <a
+              key={url}
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={color}
+            >
+              <span className="sr-only">{name}</span>
+              <Icon className="w-5 h-5" />
+            </a>
+          ))}
           <a
             href="#contact"
             className="px-4 py-2 text-sm font-medium text-white transition-transform bg-blue-600 rounded hover:bg-blue-700 hover:scale-105"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,7 +9,10 @@ export default function Hero() {
         muted
       />
       <div className="absolute inset-0 bg-black/40" />
-      <div className="relative z-10 flex flex-col items-center px-4 text-center text-white animate-fadeInUp">
+      <div
+        className="relative z-10 flex flex-col items-center px-4 text-center text-white"
+        data-aos="fade-up"
+      >
         <img
           src="/assets/img/profile.jpg"
           alt="Michaël Redant"

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -1,43 +1,133 @@
-const services = [
+import React from "react";
+import { FaLinkedin, FaGithub, FaInstagram, FaFacebook } from "react-icons/fa";
+
+interface Activity {
+  id: number;
+  name: string;
+  description: string;
+}
+
+const activities: Activity[] = [
   {
-    title: "Webdesign & development",
-    description: "Responsive sites, webshops en op maat gemaakte apps",
-    icon: "/assets/logos/css.svg",
+    id: 1,
+    name: "Contentcreatie",
+    description:
+      "Sterke content maken gaat vandaag sneller dan ooit. Met slimme AI-tools zoals GPT en DALL·E maak je in geen tijd teksten, beelden en ideeën die blijven plakken.",
   },
   {
-    title: "SEO & marketing",
-    description: "Zoekmachineoptimalisatie, campagnes en analytics",
-    icon: "/assets/logos/google-analytics.svg",
+    id: 2,
+    name: "Automatisering",
+    description:
+      "Laat je marketingcampagnes en workflows automatisch draaien met slimme AI-koppelingen. Minder handwerk, meer resultaat.",
   },
   {
-    title: "Branding & design",
-    description: "Logo's, huisstijlen en visuele content",
-    icon: "/assets/logos/adobe-illustrator.svg",
+    id: 3,
+    name: "SEO / SEA",
+    description:
+      "Zorg dat je gevonden wordt op Google, met AI-gestuurde zoekanalyse, slimme optimalisaties en gerichte campagnes.",
   },
   {
-    title: "Training & support",
-    description: "Workshops en begeleiding voor teams",
-    icon: "/assets/logos/openai.svg",
+    id: 4,
+    name: "Workshops & Trainingen",
+    description:
+      "Leer zelf aan de slag gaan met AI voor marketing, content of automatisering. Praktisch, helder en afgestemd op jouw tempo.",
+  },
+  {
+    id: 5,
+    name: "Data-gedreven Strategie",
+    description:
+      "Zet je data om in actie. Met duidelijke dashboards en inzichten bouwen we samen een strategie die werkt.",
+  },
+  {
+    id: 6,
+    name: "Webdesign",
+    description:
+      "Een frisse website die werkt op elk scherm. Visueel sterk, gebruiksvriendelijk en makkelijk aanpasbaar via een CMS.",
+  },
+  {
+    id: 7,
+    name: "Webdevelopment",
+    description:
+      "We bouwen schaalbare, performante webapplicaties op maat van jouw noden – met moderne technologie én een tikkeltje 'vibe coding'.",
+  },
+  {
+    id: 8,
+    name: "UI/UX",
+    description:
+      "Sterk design begint bij een fijne ervaring. We ontwerpen gebruiksvriendelijke interfaces met Figma die logisch aanvoelen én er goed uitzien.",
+  },
+  {
+    id: 9,
+    name: "Lokale SEO",
+    description:
+      "Word beter zichtbaar in je regio met slimme, lokaal geoptimaliseerde landingspagina’s en vindbare content.",
+  },
+];
+
+const socialLinks = [
+  {
+    name: "LinkedIn",
+    icon: FaLinkedin,
+    url: "https://www.linkedin.com/in/michael-redant",
+    color: "text-primary hover:text-hover",
+  },
+  {
+    name: "GitHub",
+    icon: FaGithub,
+    url: "https://github.com/michael-redant",
+    color: "text-text hover:text-hover",
+  },
+  {
+    name: "Instagram",
+    icon: FaInstagram,
+    url: "https://www.instagram.com/michael-redant",
+    color: "text-secondary hover:text-hover",
+  },
+  {
+    name: "Facebook",
+    icon: FaFacebook,
+    url: "https://www.facebook.com/michael-redant",
+    color: "text-blue-700 hover:text-blue-900",
   },
 ];
 
 export default function Intro() {
   return (
-    <section className="px-4 py-24 mx-auto text-center bg-white max-w-5xl animate-fadeInUp">
+    <section
+      className="px-4 py-24 mx-auto text-center bg-white max-w-5xl"
+      data-aos="fade-up"
+    >
+      <img
+        src="/assets/xinu.png"
+        alt="Xinudesign"
+        className="w-24 h-24 mx-auto mb-6"
+      />
       <h2 className="text-3xl font-semibold">Xinudesign in een notendop</h2>
       <p className="mt-4 text-gray-700">
-        Van strategie tot uitvoering: alle digitale diensten onder \u00e9\u00e9n
-        dak.
+        Van strategie tot uitvoering: alle digitale diensten onder één dak.
       </p>
-      <div className="grid gap-6 mt-12 md:grid-cols-2">
-        {services.map((service) => (
+      <div className="flex justify-center mt-6 space-x-3">
+        {socialLinks.map(({ name, icon: Icon, url, color }) => (
+          <a
+            key={url}
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`flex items-center justify-center w-10 h-10 bg-white border rounded-full ${color}`}
+          >
+            <span className="sr-only">{name}</span>
+            <Icon className="w-5 h-5" />
+          </a>
+        ))}
+      </div>
+      <div className="grid gap-6 mt-12 md:grid-cols-2 lg:grid-cols-3">
+        {activities.map((activity) => (
           <div
-            key={service.title}
+            key={activity.id}
             className="p-6 transition-transform bg-white border rounded-lg hover:-translate-y-1"
           >
-            <img src={service.icon} alt="" className="w-12 h-12 mx-auto mb-4" />
-            <h3 className="text-xl font-medium">{service.title}</h3>
-            <p className="mt-2 text-gray-700">{service.description}</p>
+            <h3 className="text-xl font-medium">{activity.name}</h3>
+            <p className="mt-2 text-gray-700">{activity.description}</p>
           </div>
         ))}
       </div>

--- a/src/components/NewSection.tsx
+++ b/src/components/NewSection.tsx
@@ -1,6 +1,9 @@
 export default function NewSection() {
   return (
-    <section className="max-w-3xl px-4 py-24 mx-auto text-center bg-white rounded-lg animate-fadeInUp">
+    <section
+      className="max-w-3xl px-4 py-24 mx-auto text-center bg-white rounded-lg"
+      data-aos="fade-up"
+    >
       <h2 className="text-3xl font-semibold">Nieuw bij Xinudesign</h2>
       <p className="mt-4 text-gray-700">
         Introductie van <span className="font-medium">Vibe Coding</span>: een

--- a/src/components/ProjectSection.tsx
+++ b/src/components/ProjectSection.tsx
@@ -1,6 +1,6 @@
 export default function ProjectSection() {
   return (
-    <section className="px-4 py-24 bg-white animate-fadeInUp">
+    <section className="px-4 py-24 bg-white" data-aos="fade-up">
       <div className="max-w-3xl mx-auto text-center">
         <h2 className="text-3xl font-semibold">Projecten</h2>
         <div className="mt-8">

--- a/src/components/Specializations.tsx
+++ b/src/components/Specializations.tsx
@@ -23,7 +23,7 @@ const items = [
 
 export default function Specializations() {
   return (
-    <section className="px-4 py-24 bg-white animate-fadeInUp">
+    <section className="px-4 py-24 bg-white" data-aos="fade-up">
       <div className="max-w-5xl mx-auto">
         <h2 className="text-3xl font-semibold text-center">Specialisaties</h2>
         <div className="grid gap-6 mt-8 md:grid-cols-2">

--- a/src/components/ToolsMarquee.tsx
+++ b/src/components/ToolsMarquee.tsx
@@ -37,11 +37,10 @@ const tools: Tool[] = [
 ];
 
 export default function ToolsMarquee() {
-
   const [isPaused, setIsPaused] = useState(false);
 
   return (
-    <section className="py-24 bg-white overflow-x-hidden animate-fadeInUp">
+    <section className="py-24 bg-white overflow-x-hidden" data-aos="fade-up">
       <div
         className="flex items-center gap-8 animate-marquee w-max"
         style={{ animationPlayState: isPaused ? "paused" : "running" }}
@@ -63,7 +62,6 @@ export default function ToolsMarquee() {
             </GlassPane>
           </div>
         ))}
-
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- swap letter-based social buttons with branded icons and recolor them
- refine service descriptions and activity names
- add scroll-triggered fade-up animations across homepage using AOS

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68931d010a308332bd8716c8e88e4ac6