### PR TITLE
feat: add contact page with php mailer

### DIFF
--- a/public/contact.php
+++ b/public/contact.php
@@ -1,0 +1,38 @@
+<?php
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$honeypot = $_POST['website'] ?? '';
+if (!empty($honeypot)) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$name = strip_tags(trim($_POST['name'] ?? ''));
+$email = filter_var($_POST['email'] ?? '', FILTER_SANITIZE_EMAIL);
+$message = strip_tags(trim($_POST['message'] ?? ''));
+
+if ($name === '' || $email === '' || $message === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+if (preg_match("/[\r\n]/", $email)) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$to = 'michael@xinudesign.be';
+$subject = "Nieuw bericht van $name";
+$body = "Naam: $name\nE-mail: $email\n\n$message";
+$headers = "From: $name <$email>\r\nReply-To: $email\r\n";
+
+$success = mail($to, $subject, $body, $headers);
+
+echo json_encode(['success' => $success]);
+exit;
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,11 @@
 import { useEffect } from "react";
 import AOS from "aos";
 import "aos/dist/aos.css";
-import Hero from "./components/Hero";
-import Intro from "./components/Intro";
-import ToolsMarquee from "./components/ToolsMarquee";
-import NewSection from "./components/NewSection";
-import Specializations from "./components/Specializations";
-import ProjectSection from "./components/ProjectSection";
-import CvSection from "./components/CvSection";
-import Footer from "./components/Footer";
 import Header from "./components/Header";
+import Footer from "./components/Footer";
+import { Routes, Route } from "react-router-dom";
+import Home from "./pages/Home";
+import Contact from "./pages/Contact";
 
 export default function App() {
   useEffect(() => {
@@ -19,13 +15,10 @@ export default function App() {
   return (
     <>
       <Header />
-      <Hero />
-      <Intro />
-      <ToolsMarquee />
-      <NewSection />
-      <Specializations />
-      <ProjectSection />
-      <CvSection />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/contact" element={<Contact />} />
+      </Routes>
       <Footer />
     </>
   );

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import GlassPane from "../components/GlassPane";
+
+const Contact: React.FC = () => {
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const data = new FormData(form);
+
+    try {
+      const res = await fetch("/contact.php", {
+        method: "POST",
+        body: data,
+      });
+      const result = await res.json();
+      if (result.success) {
+        setStatus("Bedankt voor je bericht! Ik laat snel iets weten.");
+        form.reset();
+      } else {
+        setStatus("Er liep iets mis. Probeer later opnieuw.");
+      }
+    } catch {
+      setStatus("Er liep iets mis. Probeer later opnieuw.");
+    }
+  };
+
+  return (
+    <main className="flex items-center justify-center min-h-screen p-6 bg-gradient-to-br from-white to-blue-100 dark:from-gray-900 dark:to-gray-800">
+      <GlassPane className="w-full max-w-lg p-8">
+        <h1 className="mb-6 text-3xl font-bold text-center">Contacteer mij</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="name" className="block mb-1 font-medium">
+              Naam
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              required
+              className="w-full rounded-md border border-gray-300 p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="email" className="block mb-1 font-medium">
+              E-mail
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              className="w-full rounded-md border border-gray-300 p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="message" className="block mb-1 font-medium">
+              Bericht
+            </label>
+            <textarea
+              id="message"
+              name="message"
+              rows={5}
+              required
+              className="w-full rounded-md border border-gray-300 p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div className="hidden">
+            <label htmlFor="website">Website</label>
+            <input
+              id="website"
+              name="website"
+              type="text"
+              tabIndex={-1}
+              autoComplete="off"
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full rounded-md bg-blue-600 py-2 px-4 font-medium text-white transition hover:bg-blue-700"
+          >
+            Verstuur
+          </button>
+        </form>
+        {status && <p className="mt-4 text-center">{status}</p>}
+      </GlassPane>
+    </main>
+  );
+};
+
+export default Contact;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,23 @@
+import Hero from "../components/Hero";
+import Intro from "../components/Intro";
+import ToolsMarquee from "../components/ToolsMarquee";
+import NewSection from "../components/NewSection";
+import Specializations from "../components/Specializations";
+import ProjectSection from "../components/ProjectSection";
+import CvSection from "../components/CvSection";
+
+const Home: React.FC = () => {
+  return (
+    <>
+      <Hero />
+      <Intro />
+      <ToolsMarquee />
+      <NewSection />
+      <Specializations />
+      <ProjectSection />
+      <CvSection />
+    </>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- add Home and Contact pages with routing
- implement contact form using GlassPane
- add PHP mailer with honeypot validation

## Testing
- `npm run format` (fails: Code style issues found in src/components/Intro.tsx)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689342db821083329e6e949faa930542