### PR TITLE
Add Persona Vault marketing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Contact from "./pages/Contact";
 import Cv from "./pages/Cv";
+import PersonaVault from "./pages/PersonaVault";
 
 export default function App() {
   useEffect(() => {
@@ -18,6 +19,7 @@ export default function App() {
       <Header />
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/persona-vault" element={<PersonaVault />} />
         <Route path="/cv" element={<Cv />} />
         <Route path="/contact" element={<Contact />} />
       </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ const navItems = [
   { to: "/about", label: "Over" },
   { to: "/services", label: "Services" },
   { to: "/werk", label: "Werk" }, */
+  { to: "/persona-vault", label: "Persona Vault" },
   { to: "/cv", label: "Mijn cv" },
   { to: "/contact", label: "Contact" },
 ];

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from "react-router-dom";
 export default function Hero() {
   return (
     <section className="relative flex items-center justify-center min-h-screen overflow-hidden">

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -86,7 +86,6 @@ export default function Intro() {
       <div className="absolute inset-0 -z-20 bg-gradient-to-b from-transparent to-white dark:to-black" />
       <div className="relative max-w-5xl px-4 mx-auto">
         <GlassPane className="p-8 text-center">
-         
           <h2 className="text-3xl font-semibold">Xinudesign in een notendop</h2>
           <p className="mt-4 text-gray-700 dark:text-gray-300">
             Van strategie tot uitvoering: alle digitale diensten onder één dak.

--- a/src/components/NewSection.tsx
+++ b/src/components/NewSection.tsx
@@ -1,6 +1,6 @@
 import GlassPane from "./GlassPane";
 import { FaBolt, FaMagic, FaRocket } from "react-icons/fa";
-import { Link } from 'react-router-dom';
+import { Link } from "react-router-dom";
 
 export default function NewSection() {
   return (
@@ -46,12 +46,12 @@ export default function NewSection() {
 
             <div className="mt-8 flex justify-center">
               <Link
-              to="/contact"
-              className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-violet-600 text-white font-medium shadow-lg hover:bg-violet-700 transition"
-            >
-              <FaRocket />
-              Ontdek wat we voor jou kunnen bouwen
-            </Link>
+                to="/contact"
+                className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-violet-600 text-white font-medium shadow-lg hover:bg-violet-700 transition"
+              >
+                <FaRocket />
+                Ontdek wat we voor jou kunnen bouwen
+              </Link>
             </div>
           </div>
         </GlassPane>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import GlassPane from '../components/GlassPane';
+import { useState } from "react";
+import GlassPane from "../components/GlassPane";
 
 export default function Contact() {
-  const [status,    setStatus]  = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
   const [isSending, setSending] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -14,17 +14,17 @@ export default function Contact() {
     const data = new FormData(form);
 
     try {
-      const res    = await fetch('/contact.php', { method: 'POST', body: data });
+      const res = await fetch("/contact.php", { method: "POST", body: data });
       const result = await res.json();
 
       if (result.success) {
-        setStatus('Bedankt voor je bericht! Ik neem snel contact op.');
+        setStatus("Bedankt voor je bericht! Ik neem snel contact op.");
         form.reset();
       } else {
-        setStatus('Er liep iets mis. Probeer later opnieuw.');
+        setStatus("Er liep iets mis. Probeer later opnieuw.");
       }
     } catch {
-      setStatus('Er liep iets mis. Probeer later opnieuw.');
+      setStatus("Er liep iets mis. Probeer later opnieuw.");
     } finally {
       setSending(false);
     }
@@ -81,7 +81,13 @@ export default function Contact() {
           {/* honeypot */}
           <div className="hidden">
             <label htmlFor="website">Website</label>
-            <input id="website" name="website" type="text" tabIndex={-1} autoComplete="off" />
+            <input
+              id="website"
+              name="website"
+              type="text"
+              tabIndex={-1}
+              autoComplete="off"
+            />
           </div>
 
           {/* Knop */}
@@ -90,7 +96,7 @@ export default function Contact() {
             type="submit"
             className="w-full rounded-md bg-blue-600 py-2 px-4 font-medium text-white transition hover:bg-blue-700 disabled:opacity-60"
           >
-            {isSending ? 'Versturen…' : 'Verstuur'}
+            {isSending ? "Versturen…" : "Verstuur"}
           </button>
         </form>
 

--- a/src/pages/Cv.tsx
+++ b/src/pages/Cv.tsx
@@ -1,4 +1,4 @@
-import GlassPane from '../components/GlassPane';
+import GlassPane from "../components/GlassPane";
 import {
   FaBriefcase,
   FaGraduationCap,
@@ -8,7 +8,7 @@ import {
   FaLanguage,
   FaCertificate,
   FaProjectDiagram,
-} from 'react-icons/fa';
+} from "react-icons/fa";
 
 export default function Cv() {
   return (
@@ -18,10 +18,12 @@ export default function Cv() {
         <header className="text-center" data-aos="fade-up">
           <h1 className="text-4xl font-bold text-blue-800">Michaël Redant</h1>
           <p className="mt-2 text-gray-600">
-            Provincieweg 34a · Borsbeke • +32 496 90 85 03 • michael.redant2@telenet.be
+            Provincieweg 34a · Borsbeke • +32 496 90 85 03 •
+            michael.redant2@telenet.be
           </p>
           <p className="max-w-xl mx-auto mt-3 italic text-gray-500">
-            “People rarely succeed unless they have fun in what they are doing.” – Dale Carnegie
+            “People rarely succeed unless they have fun in what they are doing.”
+            – Dale Carnegie
           </p>
         </header>
 
@@ -31,9 +33,9 @@ export default function Cv() {
             <FaUserTie /> Over mezelf
           </h2>
           <p>
-            Ik combineer een analytische blik met creatieve drive. Na 16 jaar in de optiek –
-            waarvan een groot stuk zelfstandig – leg ik mij nu toe op
-            datagedreven marketing, AI-toepassingen en webontwikkeling. Met
+            Ik combineer een analytische blik met creatieve drive. Na 16 jaar in
+            de optiek – waarvan een groot stuk zelfstandig – leg ik mij nu toe
+            op datagedreven marketing, AI-toepassingen en webontwikkeling. Met
             dashboards en glasheldere inzichten vertaal ik complexe data naar
             haalbare acties.
           </p>
@@ -218,8 +220,7 @@ function Experience({ company, role, period, location, details }: ExpProps) {
   return (
     <div>
       <h3 className="text-xl font-semibold text-blue-800">
-        {company}{' '}
-        <span className="font-normal text-gray-700">({period})</span>
+        {company} <span className="font-normal text-gray-700">({period})</span>
       </h3>
       <p className="ml-4">
         <span className="font-medium">{role}</span> – {location}. {details}
@@ -243,7 +244,14 @@ interface ProjProps {
   skills: string;
   company: string;
 }
-function Project({ title, link, period, description, skills, company }: ProjProps) {
+function Project({
+  title,
+  link,
+  period,
+  description,
+  skills,
+  company,
+}: ProjProps) {
   return (
     <div className="space-y-1">
       <a
@@ -253,7 +261,7 @@ function Project({ title, link, period, description, skills, company }: ProjProp
         className="font-semibold text-blue-800 hover:underline"
       >
         {title}
-      </a>{' '}
+      </a>{" "}
       <span className="text-gray-600">({period})</span>
       <p className="ml-4">{description}</p>
       <p className="ml-4 text-sm text-gray-700">

--- a/src/pages/PersonaVault.tsx
+++ b/src/pages/PersonaVault.tsx
@@ -1,0 +1,77 @@
+import type { IconType } from "react-icons";
+import { FaShareAlt, FaTag, FaSearch } from "react-icons/fa";
+
+const features: { icon: IconType; title: string; text: string }[] = [
+  {
+    icon: FaShareAlt,
+    title: "Share personas",
+    text: "Easily share personas and prompts with others.",
+  },
+  {
+    icon: FaTag,
+    title: "Tag-based filtering",
+    text: "Organize your vault items with flexible tags.",
+  },
+  {
+    icon: FaSearch,
+    title: "Instant search",
+    text: "Find the right persona or prompt in seconds.",
+  },
+];
+
+const PersonaVault: React.FC = () => {
+  return (
+    <main className="px-4 py-24 bg-gradient-to-b from-white to-blue-100 dark:from-gray-900 dark:to-gray-800">
+      <section
+        className="max-w-5xl mx-auto text-center space-y-6"
+        data-aos="fade-up"
+      >
+        <div className="flex justify-center">
+          <div className="h-24 w-24 rounded-full bg-gray-300 flex items-center justify-center text-gray-600">
+            Logo
+          </div>
+        </div>
+        <h1 className="text-4xl font-bold text-blue-800">Persona Vault</h1>
+        <p className="max-w-2xl mx-auto text-lg text-gray-700 dark:text-gray-300">
+          A lightweight personal vault to manage and share personas and prompts.
+        </p>
+      </section>
+
+      <section
+        className="max-w-5xl mx-auto grid gap-8 mt-16 md:grid-cols-3"
+        data-aos="fade-up"
+        data-aos-delay="100"
+      >
+        {features.map(({ icon: Icon, title, text }) => (
+          <div
+            key={title}
+            className="p-6 rounded-xl bg-white/70 dark:bg-black/30 backdrop-blur-md shadow-xl border border-white/20"
+          >
+            <Icon className="mb-4 text-3xl text-blue-600" />
+            <h3 className="mb-2 text-xl font-semibold text-blue-700">
+              {title}
+            </h3>
+            <p className="text-gray-700 dark:text-gray-300">{text}</p>
+          </div>
+        ))}
+      </section>
+
+      <section
+        className="mt-24 text-center"
+        data-aos="fade-up"
+        data-aos-delay="200"
+      >
+        <a
+          href="https://github.com/MichaelRedant/persona-vault"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block px-6 py-3 text-white transition-transform bg-blue-600 rounded hover:bg-blue-700 hover:scale-105"
+        >
+          View on GitHub
+        </a>
+      </section>
+    </main>
+  );
+};
+
+export default PersonaVault;


### PR DESCRIPTION
## Summary
- Add Persona Vault SaaS-style landing page with animated sections and feature icons
- Wire Persona Vault into router and main navigation
- Normalize CV contact info and format project files to satisfy linting/formatting

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6893507b71ec8332a16331964eb6b46f