### PR TITLE
Improve city landing pages

### DIFF
--- a/scripts/new-landing.js
+++ b/scripts/new-landing.js
@@ -19,10 +19,43 @@ const destPath = path.join(__dirname, "../src/content/landings", `${slug}.md`);
 
 const tpl = await fs.readFile(templatePath, "utf8");
 const today = new Date().toISOString().split("T")[0];
+
+let generated = "";
+try {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY niet ingesteld");
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content:
+            "Je schrijft overtuigende marketingteksten in het Nederlands.",
+        },
+        {
+          role: "user",
+          content: `Schrijf drie unieke paragrafen over webdevelopment, adverteren via Google en Meta en algemene online marketing voor kmo's in ${city}. Spreek de lezer direct aan en benadruk lokale groei.`,
+        },
+      ],
+    }),
+  });
+  const data = await res.json();
+  generated = data.choices?.[0]?.message?.content?.trim() ?? "";
+} catch {
+  generated = `**Sterke websites die scoren in ${city}.**\nWe bouwen snelle, SEO‑klare sites en versterken je zichtbaarheid met lokale signalen (NAP, reviews, GMB & structured data). Zo groei je organisch én met gerichte campagnes.`;
+}
+
 const content = tpl
   .replace(/{{City}}/g, city)
   .replace(/{{slug}}/g, slug)
-  .replace(/YYYY-MM-DD/g, today);
+  .replace(/YYYY-MM-DD/g, today)
+  .replace(/{{content}}/, generated);
 
 await fs.writeFile(destPath, content);
 console.log(`✅ Landingspagina aangemaakt: ${destPath}`);

--- a/scripts/templates/landing.md
+++ b/scripts/templates/landing.md
@@ -13,8 +13,12 @@ secondaryKeywords:
 description: "Zoek je een webdeveloper of SEA, SEO‑specialist in {{City}}? Xinudesign helpt kmo’s met snelle, vindbare websites, AI‑marketing en lokale SEO."
 canonical: "https://www.xinudesign.be/lokale-seo/{{slug}}"
 services:
-  - name: "SEO / SEA"
-    short: "Zorg dat je gevonden wordt op Google, met AI‑gestuurde analyses en gerichte campagnes."
+  - name: "Webdevelopment"
+    short: "Maatwerk websites met focus op snelheid, SEO en conversie."
+  - name: "Advertising (Google & Meta)"
+    short: "Gerichte campagnes via Google Ads en Meta voor meer leads."
+  - name: "Online marketing"
+    short: "Strategieën en content die je merk lokaal doet groeien."
 related:
   - title: "SEO tips voor kmo's"
     url: "/blog/seo-tips"
@@ -24,5 +28,4 @@ faqs:
 lastmod: "YYYY-MM-DD"
 ---
 
-**Sterke websites die scoren in {{City}}.**
-We bouwen snelle, SEO‑klare sites en versterken je zichtbaarheid met lokale signalen (NAP, reviews, GMB & structured data). Zo groei je organisch én met gerichte campagnes.
+{{content}}

--- a/src/components/RegionSection.tsx
+++ b/src/components/RegionSection.tsx
@@ -35,12 +35,10 @@ export default function RegionSection() {
             <a
               key={link.slug}
               href={`/lokale-seo/${link.slug}`}
-
               className={[
                 "p-4 text-center rounded border border-slate-200 dark:border-slate-700",
                 "hover:bg-blue-50 dark:hover:bg-gray-800 transition",
               ].join(" ")}
-
             >
               {link.city}
             </a>

--- a/src/content/landings/aalst.md
+++ b/src/content/landings/aalst.md
@@ -13,8 +13,12 @@ secondaryKeywords:
 description: "Zoek je een webdeveloper of SEA, SEO‑specialist in Aalst? Xinudesign helpt kmo’s met snelle, vindbare websites, AI‑marketing en lokale SEO."
 canonical: "https://www.xinudesign.be/lokale-seo/aalst"
 services:
-  - name: "SEO / SEA"
-    short: "Zorg dat je gevonden wordt op Google, met AI‑gestuurde analyses en gerichte campagnes."
+  - name: "Webdevelopment"
+    short: "Maatwerk websites met focus op snelheid, SEO en conversie."
+  - name: "Advertising (Google & Meta)"
+    short: "Gerichte campagnes via Google Ads en Meta voor meer leads."
+  - name: "Online marketing"
+    short: "Strategieën en content die je merk lokaal doet groeien."
 related:
   - title: "SEO tips voor kmo's"
     url: "/blog/seo-tips"
@@ -24,5 +28,11 @@ faqs:
 lastmod: "2025-08-08"
 ---
 
-**Sterke websites die scoren in Aalst.**
-We bouwen snelle, SEO‑klare sites en versterken je zichtbaarheid met lokale signalen (NAP, reviews, GMB & structured data). Zo groei je organisch én met gerichte campagnes.
+**Digitale groei voor ondernemers in Aalst**
+Wij bouwen performante websites op maat van Aalsterse kmo’s. Met moderne frameworks en een focus op conversie krijgt je bedrijf een site die snel laadt en klaar is voor SEO.
+
+**Slim adverteren in Aalst**
+Via doelgerichte Google- en Meta-campagnes bereik je de juiste mensen in en rond Aalst. We optimaliseren op basis van data zodat elk advertentiebudget maximaal rendeert.
+
+**Online marketing die resultaten oplevert**
+Content, e-mail en automatisaties versterken je digitale aanwezigheid. Dankzij lokale SEO-signalen en continue optimalisatie groeit jouw zaak in Aalst stap voor stap online.

--- a/src/content/landings/herzele.md
+++ b/src/content/landings/herzele.md
@@ -22,16 +22,12 @@ geo:
   lat: 50.8862
   lng: 3.8864
 services:
-  - name: "SEO / SEA"
-    short: "Zorg dat je gevonden wordt op Google, met AI‑gestuurde analyses en gerichte campagnes."
-  - name: "Data‑gedreven Strategie"
-    short: "Zet data om in actie via dashboards en duidelijke inzichten."
   - name: "Webdevelopment"
-    short: "Schaalbare, performante webapps met een tikkeltje ‘vibe coding’."
-  - name: "UI/UX"
-    short: "Gebruiksvriendelijke interfaces in Figma, logisch én mooi."
-  - name: "Lokale SEO"
-    short: "Slimme, lokaal geoptimaliseerde content die converteert."
+    short: "Maatwerk websites met focus op snelheid, SEO en conversie."
+  - name: "Advertising (Google & Meta)"
+    short: "Gerichte campagnes via Google Ads en Meta voor meer leads."
+  - name: "Online marketing"
+    short: "Strategieën en content die je merk lokaal doet groeien."
 faqs:
   - q: "Werken jullie ook op locatie in Herzele?"
     a: "Ja. We werken hybride: remote en op locatie indien nodig."
@@ -47,5 +43,11 @@ related:
 lastmod: "2025-08-08"
 ---
 
-**Sterke websites die scoren in Herzele.**  
-We bouwen snelle, SEO‑klare sites en versterken je zichtbaarheid met lokale signalen (NAP, reviews, GMB & structured data). Zo groei je organisch én met gerichte campagnes.
+**Digitale oplossingen voor Herzeelse kmo’s**
+We ontwikkelen snelle en schaalbare websites die inspelen op de noden van ondernemingen in Herzele. Je site wordt gebouwd met oog voor conversie en geoptimaliseerd voor zoekmachines.
+
+**Bereik je publiek met slimme advertenties**
+Met advertenties op Google en Meta spreken we inwoners van Herzele en omstreken gericht aan. Via continue A/B‑testing en rapportage halen we het maximum uit je marketingbudget.
+
+**Online marketing die je merk versterkt**
+We combineren lokale SEO, contentcreatie en marketingautomatisatie om je bedrijf in Herzele duurzaam te laten groeien. Geen losse acties, maar een doordachte digitale strategie.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App.tsx";
 import { Buffer } from "buffer";
-(window as any).Buffer = Buffer;
+(window as unknown as { Buffer: typeof Buffer }).Buffer = Buffer;
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/pages/LokaleSeoPage.tsx
+++ b/src/pages/LokaleSeoPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { useEffect, useMemo, useState } from "react";
 import matter from "gray-matter";
 import MarkdownIt from "markdown-it";
+import { FaBullhorn, FaChartLine, FaCode } from "react-icons/fa";
 
 const md = new MarkdownIt({ html: true, linkify: true });
 
@@ -212,10 +213,15 @@ export default function LokaleSeoPage() {
     );
   }
 
-  return (
+  const icons: Record<string, React.ComponentType> = {
+    Webdevelopment: FaCode,
+    "Advertising (Google & Meta)": FaBullhorn,
+    "Online marketing": FaChartLine,
+  };
 
+  return (
     <main>
-      <section className="px-4 py-24 text-center bg-gradient-to-r from-blue-600 to-sky-500 text-white">
+      <section className="px-4 py-24 text-center bg-gradient-to-br from-blue-600 via-purple-600 to-sky-500 text-white">
         <div className="max-w-3xl mx-auto">
           <h1 className="text-4xl font-bold mb-4">{fm.h1 ?? fm.title}</h1>
           <p className="text-lg opacity-90">{fm.description}</p>
@@ -228,37 +234,28 @@ export default function LokaleSeoPage() {
         </div>
       </section>
 
-      <article className="prose prose-slate dark:prose-invert max-w-3xl mx-auto px-4 py-16">
+      <article className="prose prose-slate dark:prose-invert max-w-4xl mx-auto px-4 py-16">
         {fm.services?.length ? (
-          <ul className="not-prose my-8 grid gap-4 sm:grid-cols-2">
-            {fm.services.map((s) => (
-              <li
-                key={s.name}
-                className="p-4 rounded border border-slate-200 dark:border-slate-700"
-              >
-                <strong>{s.name}:</strong> {s.short}
-              </li>
-            ))}
-          </ul>
+          <div className="not-prose my-12 grid gap-6 md:grid-cols-3">
+            {fm.services.map((s) => {
+              const Icon = icons[s.name] ?? FaCode;
+              return (
+                <div
+                  key={s.name}
+                  className="p-6 bg-white dark:bg-slate-800 rounded-xl shadow border border-slate-100 dark:border-slate-700"
+                >
+                  <Icon className="w-6 h-6 text-blue-600 mb-4" />
+                  <h3 className="text-lg font-semibold mb-2">{s.name}</h3>
+                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                    {s.short}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
         ) : null}
 
         <section dangerouslySetInnerHTML={{ __html: html }} />
-
-        {fm.related?.length ? (
-          <section className="mt-12">
-            <h2>Lees ook</h2>
-            <ul className="list-disc ml-5">
-              {fm.related.map((r) => (
-                <li key={r.url}>
-                  <a href={r.url} className="text-blue-600 hover:underline">
-                    {r.title}
-                  </a>
-
-                </li>
-              ))}
-            </ul>
-          </section>
-        ) : null}
 
         {fm.related?.length ? (
           <section className="mt-12">


### PR DESCRIPTION
## Summary
- generate unique city copy via OpenAI in landing script
- expand landing template with SaaS-focused services and content placeholder
- overhaul local SEO page layout with icon cards and update city markdown

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68965a7d35e08332b70976693ec1a24f