### PR TITLE
Improve SEO metadata for city landing pages

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -5,19 +5,38 @@ interface SeoProps {
   description?: string;
   canonical?: string;
   jsonLd?: Record<string, unknown> | Record<string, unknown>[];
+  image?: string;
+  keywords?: string[];
 }
 
-const Seo: React.FC<SeoProps> = ({ title, description, canonical, jsonLd }) => {
+const Seo: React.FC<SeoProps> = ({
+  title,
+  description,
+  canonical,
+  jsonLd,
+  image,
+  keywords,
+}) => {
   const jsonLdArray = Array.isArray(jsonLd) ? jsonLd : jsonLd ? [jsonLd] : [];
+  const keywordContent = keywords?.join(", ");
   return (
     <Helmet>
       <title>{title}</title>
       {description && <meta name="description" content={description} />}
+      {keywordContent && <meta name="keywords" content={keywordContent} />}
       {canonical && <link rel="canonical" href={canonical} />}
+      {canonical && <link rel="alternate" hrefLang="nl-be" href={canonical} />}
       <meta property="og:type" content="website" />
       <meta property="og:title" content={title} />
       {description && <meta property="og:description" content={description} />}
       {canonical && <meta property="og:url" content={canonical} />}
+      {image && <meta property="og:image" content={image} />}
+      <meta property="og:site_name" content="Xinudesign" />
+      <meta property="og:locale" content="nl_BE" />
+      {image && <meta name="twitter:card" content="summary_large_image" />}
+      <meta name="twitter:title" content={title} />
+      {description && <meta name="twitter:description" content={description} />}
+      {image && <meta name="twitter:image" content={image} />}
       {jsonLdArray.map((obj, index) => (
         <script
           dangerouslySetInnerHTML={{ __html: JSON.stringify(obj) }}

--- a/src/pages/LokaleSeoPage.tsx
+++ b/src/pages/LokaleSeoPage.tsx
@@ -109,6 +109,11 @@ export default function LokaleSeoPage() {
   // Defaults voor media
   const heroVideo = fm.video || "/assets/video/ai_video.mp4";
   const cityImage = fm.image || `/assets/img/landingpages/${fm.slug}.png`;
+  const imageUrl = `https://www.xinudesign.be${cityImage}`;
+  const keywordList = [
+    fm.primaryKeyword,
+    ...(fm.secondaryKeywords ?? []),
+  ].filter(Boolean) as string[];
 
   const jsonLd: Record<string, unknown>[] = [];
   if (fm.address) {
@@ -116,7 +121,8 @@ export default function LokaleSeoPage() {
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       name: "Xinudesign",
-      image: "https://www.xinudesign.be/apple-touch-icon.png",
+      image: imageUrl,
+      logo: "https://www.xinudesign.be/apple-touch-icon.png",
       url: fm.canonical,
       telephone: fm.phone,
       email: fm.email,
@@ -124,10 +130,12 @@ export default function LokaleSeoPage() {
         "@type": "PostalAddress",
         streetAddress: fm.address.street,
         addressLocality: fm.address.locality,
+        ...(fm.province ? { addressRegion: fm.province } : {}),
         postalCode: fm.address.postalCode,
         addressCountry: fm.address.country,
       },
       areaServed: fm.city,
+      ...(keywordList.length ? { keywords: keywordList.join(", ") } : {}),
       ...(fm.geo
         ? {
             geo: {
@@ -183,6 +191,8 @@ export default function LokaleSeoPage() {
         description={fm.description}
         canonical={fm.canonical}
         jsonLd={jsonLd}
+        image={imageUrl}
+        keywords={keywordList}
       />
       <main className="relative overflow-hidden">
         {/* HERO: vaste video + stadsspecifieke image overlay */}


### PR DESCRIPTION
## Summary
- expand `<Seo>` component with keywords, hreflang, Open Graph, and Twitter tags
- feed city-specific image and keyword list to `<Seo>`
- include keywords in LocalBusiness schema for local pages

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68990cbeb2c88332ac28ec7b1cc9cd84