### PR TITLE
feat: add portfolio page with Pixapop collaboration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Cv from "./pages/Cv";
 import PersonaVault from "./pages/PersonaVault";
 import LokaleSeoPage from "./pages/LokaleSeoPage";
 import RegionSection from "./components/RegionSection";
+import Portfolio from "./pages/Portfolio";
 
 export default function App() {
   useEffect(() => {
@@ -25,6 +26,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/persona-vault" element={<PersonaVault />} />
+          <Route path="/portfolio" element={<Portfolio />} />
           <Route path="/cv" element={<Cv />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="/diensten/:city" element={<LokaleSeoPage />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { to: "/services", label: "Services" },
   { to: "/werk", label: "Werk" }, */
   { to: "/persona-vault", label: "Persona Vault" },
+  { to: "/portfolio", label: "Portfolio" },
   { to: "/cv", label: "Mijn cv" },
   { to: "/contact", label: "Contact" },
 ];

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,0 +1,91 @@
+import GlassPane from "../components/GlassPane";
+import Seo from "../components/Seo";
+
+interface PortfolioItem {
+  title: string;
+  description: string;
+  link: string;
+}
+
+const items: PortfolioItem[] = [
+  {
+    title: "Website voor lokale bakkerij",
+    description: "Responsive site met focus op bestelgemak.",
+    link: "https://pixapop.be/webdesign-realisaties/",
+  },
+  {
+    title: "Portfolio van creatief bureau",
+    description: "Lichte animaties en CMS-integratie.",
+    link: "https://pixapop.be/webdesign-realisaties/",
+  },
+  {
+    title: "E-commerce platform voor fashion retailer",
+    description: "Snel ladende shop met maatwerk design.",
+    link: "https://pixapop.be/webdesign-realisaties/",
+  },
+];
+
+export default function Portfolio() {
+  return (
+    <>
+      <Seo
+        title="Portfolio | Xinudesign"
+        description="Een selectie van projecten gerealiseerd in samenwerking met webdesigner Pixapop."
+        canonical="https://www.xinudesign.be/portfolio"
+      />
+      <main className="px-4 py-24 bg-gradient-to-b from-white to-blue-100 dark:from-gray-900 dark:to-gray-800">
+        <GlassPane className="max-w-5xl mx-auto p-8 space-y-8">
+          <header className="text-center" data-aos="fade-up">
+            <h1 className="text-4xl font-bold text-blue-800">Portfolio</h1>
+            <p className="mt-4 text-gray-700 dark:text-gray-300">
+              Voor webdesign werk ik samen met{" "}
+              <a
+                href="https://www.pixapop.be"
+                className="text-blue-600 underline hover:text-blue-800"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Pixapop
+              </a>
+              . Ontdek enkele realisaties hieronder of bekijk er meer op{" "}
+              <a
+                href="https://pixapop.be/webdesign-realisaties/"
+                className="text-blue-600 underline hover:text-blue-800"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                pixapop.be
+              </a>
+              .
+            </p>
+          </header>
+          <section
+            className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
+            data-aos="fade-up"
+            data-aos-delay="100"
+          >
+            {items.map(({ title, description, link }) => (
+              <div
+                key={title}
+                className="p-6 rounded-xl bg-white/30 dark:bg-white/10 border border-white/25 dark:border-white/15 shadow-lg"
+              >
+                <h3 className="text-xl font-semibold">{title}</h3>
+                <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
+                  {description}
+                </p>
+                <a
+                  href={link}
+                  className="inline-block mt-4 text-blue-600 hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Bekijk project
+                </a>
+              </div>
+            ))}
+          </section>
+        </GlassPane>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add Portfolio page highlighting webdesign partnership with Pixapop
- link portfolio in navigation and routing

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68992282424083328da714f4bc901d1c