### PR TITLE
Modernize portfolio section with responsive modals

### DIFF
--- a/src/components/GlassPane.tsx
+++ b/src/components/GlassPane.tsx
@@ -1,13 +1,15 @@
-interface GlassPaneProps {
+interface GlassPaneProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   className?: string;
 }
 export default function GlassPane({
   children,
   className = "",
+  ...props
 }: GlassPaneProps) {
   return (
     <div
+      {...props}
       className={`bg-white/30 dark:bg-white/10 backdrop-blur-md border border-white/25 dark:border-white/15 rounded-xl shadow-lg ${className}`}
     >
       {children}

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { FaLinkedin, FaGithub, FaInstagram, FaFacebook } from "react-icons/fa";
 
-
 interface Activity {
   id: number;
   name: string;
@@ -16,13 +15,11 @@ const activities: Activity[] = [
     name: "Contentcreatie",
     description:
       "Sterke content maken gaat vandaag sneller dan ooit. Met slimme AI-tools zoals GPT en DALL·E maak je in geen tijd teksten, beelden en ideeën die blijven plakken.",
-
   },
   {
     id: 2,
     name: "Automatisering",
     description:
-
       "Laat je marketingcampagnes en workflows automatisch draaien met slimme AI-koppelingen. Minder handwerk, meer resultaat.",
   },
   {
@@ -42,45 +39,35 @@ const activities: Activity[] = [
     name: "Data-gedreven Strategie",
     description:
       "Zet je data om in actie. Met duidelijke dashboards en inzichten bouwen we samen een strategie die werkt.",
-
   },
   {
     id: 6,
     name: "Webdesign",
     description:
-
       "Een frisse website die werkt op elk scherm. Visueel sterk, gebruiksvriendelijk en makkelijk aanpasbaar via een CMS.",
-
   },
   {
     id: 7,
     name: "Webdevelopment",
     description:
-
       "We bouwen schaalbare, performante webapplicaties op maat van jouw noden – met moderne technologie én een tikkeltje 'vibe coding'.",
-
   },
   {
     id: 8,
     name: "UI/UX",
     description:
-
       "Sterk design begint bij een fijne ervaring. We ontwerpen gebruiksvriendelijke interfaces met Figma die logisch aanvoelen én er goed uitzien.",
-
   },
   {
     id: 9,
     name: "Lokale SEO",
     description:
-
       "Word beter zichtbaar in je regio met slimme, lokaal geoptimaliseerde landingspagina’s en vindbare content.",
-
   },
 ];
 
 const socialLinks = [
   {
-
     name: "LinkedIn",
     icon: FaLinkedin,
     url: "https://www.linkedin.com/in/michael-redant",
@@ -103,18 +90,15 @@ const socialLinks = [
     icon: FaFacebook,
     url: "https://www.facebook.com/michael-redant",
     color: "text-blue-700 hover:text-blue-900",
-
   },
 ];
 
 export default function Intro() {
   return (
-
     <section
       className="px-4 py-24 mx-auto text-center bg-white max-w-5xl"
       data-aos="fade-up"
     >
-
       <img
         src="/assets/xinu.png"
         alt="Xinudesign"
@@ -125,7 +109,6 @@ export default function Intro() {
         Van strategie tot uitvoering: alle digitale diensten onder één dak.
       </p>
       <div className="flex justify-center mt-6 space-x-3">
-
         {socialLinks.map(({ name, icon: Icon, url, color }) => (
           <a
             key={url}
@@ -136,7 +119,6 @@ export default function Intro() {
           >
             <span className="sr-only">{name}</span>
             <Icon className="w-5 h-5" />
-
           </a>
         ))}
       </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,26 @@
+interface ModalProps {
+  children: React.ReactNode;
+  onClose: () => void;
+}
+
+export default function Modal({ children, onClose }: ModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-white/10 backdrop-blur-2xl"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-11/12 max-w-lg p-6 bg-white/30 dark:bg-black/30 backdrop-blur-md rounded-2xl shadow-xl border border-white/20"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+        <button
+          onClick={onClose}
+          className="absolute transition top-2 right-2 text-white hover:text-red-500"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectSection.tsx
+++ b/src/components/ProjectSection.tsx
@@ -1,20 +1,68 @@
+import { useState } from "react";
+import GlassPane from "./GlassPane";
+import Modal from "./Modal";
+
+interface Project {
+  title: string;
+  shortDescription: string;
+  description: string;
+  link: string;
+}
+
+const projects: Project[] = [
+  {
+    title: "Persona Vault",
+    shortDescription: "Placeholdertekst over dit subdomeinproject.",
+    description:
+      "Een moderne tool waarmee je persona's veilig kan beheren en delen.",
+    link: "https://personavault.xinudesign.be",
+  },
+  {
+    title: "Xinudesign Website",
+    shortDescription: "Deze website toont mijn diensten en stijl.",
+    description:
+      "Portfolio site gebouwd met React, Tailwind en een vleugje futurisme.",
+    link: "https://xinudesign.be",
+  },
+];
+
 export default function ProjectSection() {
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+
   return (
-    <section className="px-4 py-24 bg-white" data-aos="fade-up">
-      <div className="max-w-3xl mx-auto text-center">
+    <section
+      className="px-4 py-24 bg-gradient-to-b from-white to-blue-50"
+      data-aos="fade-up"
+    >
+      <div className="max-w-5xl mx-auto text-center">
         <h2 className="text-3xl font-semibold">Projecten</h2>
-        <div className="mt-8">
-          <a
-            href="https://personavault.xinudesign.be"
-            className="block p-6 transition-transform border rounded-lg hover:scale-105 hover:bg-white"
-          >
-            <h3 className="text-xl font-medium">Persona Vault</h3>
-            <p className="mt-2 text-gray-700">
-              Placeholdertekst over dit subdomeinproject.
-            </p>
-          </a>
+        <div className="grid max-w-5xl gap-6 mt-10 sm:grid-cols-2 lg:grid-cols-3">
+          {projects.map((project) => (
+            <GlassPane
+              key={project.title}
+              className="p-6 transition-transform cursor-pointer hover:scale-105"
+              onClick={() => setSelectedProject(project)}
+            >
+              <h3 className="text-xl font-medium">{project.title}</h3>
+              <p className="mt-2 text-gray-700">{project.shortDescription}</p>
+            </GlassPane>
+          ))}
         </div>
       </div>
+      {selectedProject && (
+        <Modal onClose={() => setSelectedProject(null)}>
+          <h3 className="text-2xl font-semibold">{selectedProject.title}</h3>
+          <p className="mt-4 text-gray-700">{selectedProject.description}</p>
+          <a
+            href={selectedProject.link}
+            className="inline-block mt-6 text-blue-600 underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Bekijk project
+          </a>
+        </Modal>
+      )}
     </section>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -22,8 +22,12 @@ body {
 
 /* (voorbeelden) marquee-keyframes - plaats dit alleen als je ze nog niet had */
 @keyframes marquee {
-  from { transform: translateX(0); }
-  to   { transform: translateX(-50%); }
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
 }
 .animate-marquee {
   animation: marquee 28s linear infinite;


### PR DESCRIPTION
## Summary
- revamp portfolio section into responsive grid using glass cards and modal overlays
- add reusable Modal component with close button and liquid glass effect
- adjust GlassPane to accept HTML attributes and run Prettier formatting

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68998bf811e48332873791e62278f3e4