### PR TITLE
Add dedicated service pages for marketing offerings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,12 @@ const Cv = lazy(() => import("./pages/Cv"));
 const PersonaVault = lazy(() => import("./pages/PersonaVault"));
 const LokaleSeoPage = lazy(() => import("./pages/LokaleSeoPage"));
 const Portfolio = lazy(() => import("./pages/Portfolio"));
+const SeoSea = lazy(() => import("./pages/SeoSea"));
+const DataStrategy = lazy(() => import("./pages/DataStrategy"));
+const Webdesign = lazy(() => import("./pages/Webdesign"));
+const Webdevelopment = lazy(() => import("./pages/Webdevelopment"));
+const UiUx = lazy(() => import("./pages/UiUx"));
+const LokaleSeo = lazy(() => import("./pages/LokaleSeo"));
 
 export default function App() {
   useEffect(() => {
@@ -31,6 +37,18 @@ export default function App() {
             <Route path="/portfolio" element={<Portfolio />} />
             <Route path="/cv" element={<Cv />} />
             <Route path="/contact" element={<Contact />} />
+            <Route path="/diensten/seo-sea" element={<SeoSea />} />
+            <Route
+              path="/diensten/data-gedreven-strategie"
+              element={<DataStrategy />}
+            />
+            <Route path="/diensten/webdesign" element={<Webdesign />} />
+            <Route
+              path="/diensten/webdevelopment"
+              element={<Webdevelopment />}
+            />
+            <Route path="/diensten/ui-ux" element={<UiUx />} />
+            <Route path="/diensten/lokale-seo" element={<LokaleSeo />} />
             <Route path="/diensten/:city" element={<LokaleSeoPage />} />
           </Routes>
         </Suspense>

--- a/src/pages/DataStrategy.tsx
+++ b/src/pages/DataStrategy.tsx
@@ -1,0 +1,46 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const DataStrategy: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="Data-gedreven strategie | Xinudesign"
+        description="Zet je data om in actie met duidelijke dashboards en inzichten die je groei versnellen."
+        canonical="https://www.xinudesign.be/diensten/data-gedreven-strategie"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">
+          Data-gedreven strategie
+        </h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Zet je data om in actie. Met duidelijke dashboards en inzichten bouwen
+          we samen een strategie die werkt.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Heldere dashboards
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Actiegericht advies
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Strategie die rendeert
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default DataStrategy;

--- a/src/pages/LokaleSeo.tsx
+++ b/src/pages/LokaleSeo.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const LokaleSeo: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="Lokale SEO | Xinudesign"
+        description="Word beter zichtbaar in je regio met slimme, lokaal geoptimaliseerde landingspagina’s en vindbare content."
+        canonical="https://www.xinudesign.be/diensten/lokale-seo"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">Lokale SEO</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Word beter zichtbaar in je regio met slimme, lokaal geoptimaliseerde
+          landingspagina’s en vindbare content.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Lokaal geoptimaliseerde pagina’s
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Vindbare content
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Meer klanten in je regio
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default LokaleSeo;

--- a/src/pages/SeoSea.tsx
+++ b/src/pages/SeoSea.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const SeoSea: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="SEO & SEA | Xinudesign"
+        description="Scoor hoger in Google met AI-gestuurde zoekanalyse, slimme optimalisaties en gerichte campagnes."
+        canonical="https://www.xinudesign.be/diensten/seo-sea"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">SEO &amp; SEA</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Zorg dat je gevonden wordt op Google met AI-gestuurde zoekanalyse,
+          slimme optimalisaties en gerichte campagnes.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            AI-gestuurde zoekanalyse
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Slimme optimalisaties
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Gerichte campagnes
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default SeoSea;

--- a/src/pages/UiUx.tsx
+++ b/src/pages/UiUx.tsx
@@ -1,0 +1,45 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const UiUx: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="UI/UX design | Xinudesign"
+        description="Sterk design begint bij een fijne ervaring. We ontwerpen gebruiksvriendelijke interfaces met Figma die logisch aanvoelen én er goed uitzien."
+        canonical="https://www.xinudesign.be/diensten/ui-ux"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">UI/UX</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Sterk design begint bij een fijne ervaring. We ontwerpen
+          gebruiksvriendelijke interfaces met Figma die logisch aanvoelen én er
+          goed uitzien.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Figma prototypes
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Logische flows
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Pixel-perfect visuals
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default UiUx;

--- a/src/pages/Webdesign.tsx
+++ b/src/pages/Webdesign.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const Webdesign: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="Webdesign | Xinudesign"
+        description="Een frisse website die werkt op elk scherm. Visueel sterk, gebruiksvriendelijk en makkelijk aanpasbaar via een CMS."
+        canonical="https://www.xinudesign.be/diensten/webdesign"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">Webdesign</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Een frisse website die werkt op elk scherm. Visueel sterk,
+          gebruiksvriendelijk en makkelijk aanpasbaar via een CMS.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Responsive design
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Visueel sterk
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            CMS dat je zelf beheert
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default Webdesign;

--- a/src/pages/Webdevelopment.tsx
+++ b/src/pages/Webdevelopment.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const Webdevelopment: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="Webdevelopment | Xinudesign"
+        description="We bouwen schaalbare, performante webapplicaties op maat van jouw noden – met moderne technologie én een tikkeltje 'vibe coding'."
+        canonical="https://www.xinudesign.be/diensten/webdevelopment"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">Webdevelopment</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          We bouwen schaalbare, performante webapplicaties op maat van jouw
+          noden – met moderne technologie én een tikkeltje 'vibe coding'.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Moderne stack
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Schaalbaar &amp; performant
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Vibe coding
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default Webdevelopment;


### PR DESCRIPTION
## Summary
- add separate pages for SEO/SEA, data-driven strategy, webdesign, webdevelopment, UI/UX and local SEO
- wire up new service routes in `App.tsx`

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689c58e2a5bc83328e405bde80168110