### PR TITLE
Add service navigation links and header dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,12 @@ const Cv = lazy(() => import("./pages/Cv"));
 const PersonaVault = lazy(() => import("./pages/PersonaVault"));
 const LokaleSeoPage = lazy(() => import("./pages/LokaleSeoPage"));
 const Portfolio = lazy(() => import("./pages/Portfolio"));
+const SeoSea = lazy(() => import("./pages/SeoSea"));
+const DataStrategy = lazy(() => import("./pages/DataStrategy"));
+const Webdesign = lazy(() => import("./pages/Webdesign"));
+const Webdevelopment = lazy(() => import("./pages/Webdevelopment"));
+const UiUx = lazy(() => import("./pages/UiUx"));
+const LokaleSeo = lazy(() => import("./pages/LokaleSeo"));
 
 export default function App() {
   useEffect(() => {
@@ -31,6 +37,18 @@ export default function App() {
             <Route path="/portfolio" element={<Portfolio />} />
             <Route path="/cv" element={<Cv />} />
             <Route path="/contact" element={<Contact />} />
+            <Route path="/diensten/seo-sea" element={<SeoSea />} />
+            <Route
+              path="/diensten/data-gedreven-strategie"
+              element={<DataStrategy />}
+            />
+            <Route path="/diensten/webdesign" element={<Webdesign />} />
+            <Route
+              path="/diensten/webdevelopment"
+              element={<Webdevelopment />}
+            />
+            <Route path="/diensten/ui-ux" element={<UiUx />} />
+            <Route path="/diensten/lokale-seo" element={<LokaleSeo />} />
             <Route path="/diensten/:city" element={<LokaleSeoPage />} />
           </Routes>
         </Suspense>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, NavLink } from "react-router-dom";
-import { FaBars, FaTimes } from "react-icons/fa";
+import { FaBars, FaTimes, FaChevronDown } from "react-icons/fa";
+import { services as serviceLinks } from "../data/services";
 
 const navItems = [
   /* { to: "/", label: "Home" },
@@ -66,6 +67,28 @@ export default function Header() {
 
         {/* ─────────────── Navigatie desktop ─────────────── */}
         <ul className="hidden md:flex gap-12">
+          <li className="relative group">
+            <button
+              className={`flex items-center gap-1 py-2 font-medium transition-colors ${
+                scrolled ? "text-gray-800" : "text-black"
+              } hover:text-[#509ef1]`}
+            >
+              Services
+              <FaChevronDown className="text-sm transition-transform group-hover:rotate-180" />
+            </button>
+            <ul className="absolute left-0 mt-2 w-56 flex-col rounded-md bg-white shadow-lg opacity-0 invisible group-hover:visible group-hover:opacity-100 transform -translate-y-2 group-hover:translate-y-0 transition-all duration-200">
+              {serviceLinks.map(({ to, name }) => (
+                <li key={to}>
+                  <NavLink
+                    to={to}
+                    className="block px-4 py-2 text-gray-800 hover:bg-gray-100"
+                  >
+                    {name}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </li>
           {navItems.map(({ to, label }) => (
             <li key={to}>
               <NavLink
@@ -96,6 +119,22 @@ export default function Header() {
               scrolled ? "bg-white/90" : "bg-white/80"
             }`}
           >
+            <li className="w-full text-center">
+              <span className="font-medium text-gray-800">Services</span>
+              <ul className="mt-2 flex flex-col gap-2">
+                {serviceLinks.map(({ to, name }) => (
+                  <li key={to}>
+                    <NavLink
+                      to={to}
+                      onClick={() => setMenuOpen(false)}
+                      className="text-gray-800"
+                    >
+                      {name}
+                    </NavLink>
+                  </li>
+                ))}
+              </ul>
+            </li>
             {navItems.map(({ to, label }) => (
               <li key={to}>
                 <NavLink

--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -2,52 +2,8 @@ import React from "react";
 
 import { FaLinkedin, FaGithub, FaInstagram, FaFacebook } from "react-icons/fa";
 import GlassPane from "./GlassPane";
-
-interface Activity {
-  id: number;
-  name: string;
-  description: string;
-}
-
-const activities: Activity[] = [
-  {
-    id: 3,
-    name: "SEO / SEA",
-    description:
-      "Zorg dat je gevonden wordt op Google, met AI-gestuurde zoekanalyse, slimme optimalisaties en gerichte campagnes.",
-  },
-
-  {
-    id: 5,
-    name: "Data-gedreven Strategie",
-    description:
-      "Zet je data om in actie. Met duidelijke dashboards en inzichten bouwen we samen een strategie die werkt.",
-  },
-  {
-    id: 6,
-    name: "Webdesign",
-    description:
-      "Een frisse website die werkt op elk scherm. Visueel sterk, gebruiksvriendelijk en makkelijk aanpasbaar via een CMS.",
-  },
-  {
-    id: 7,
-    name: "Webdevelopment",
-    description:
-      "We bouwen schaalbare, performante webapplicaties op maat van jouw noden – met moderne technologie én een tikkeltje 'vibe coding'.",
-  },
-  {
-    id: 8,
-    name: "UI/UX",
-    description:
-      "Sterk design begint bij een fijne ervaring. We ontwerpen gebruiksvriendelijke interfaces met Figma die logisch aanvoelen én er goed uitzien.",
-  },
-  {
-    id: 9,
-    name: "Lokale SEO",
-    description:
-      "Word beter zichtbaar in je regio met slimme, lokaal geoptimaliseerde landingspagina’s en vindbare content.",
-  },
-];
+import { Link } from "react-router-dom";
+import { services } from "../data/services";
 
 const socialLinks = [
   {
@@ -105,16 +61,17 @@ export default function Intro() {
             ))}
           </div>
           <div className="grid gap-6 mt-12 md:grid-cols-2 lg:grid-cols-3">
-            {activities.map((activity) => (
-              <div
-                key={activity.id}
-                className="p-6 transition-transform bg-white/80 dark:bg-black/20 border rounded-lg hover:-translate-y-1"
+            {services.map(({ name, description, to }) => (
+              <Link
+                key={to}
+                to={to}
+                className="block p-6 transition-transform bg-white/80 dark:bg-black/20 border rounded-lg hover:-translate-y-1"
               >
-                <h3 className="text-xl font-medium">{activity.name}</h3>
+                <h3 className="text-xl font-medium">{name}</h3>
                 <p className="mt-2 text-gray-700 dark:text-gray-300">
-                  {activity.description}
+                  {description}
                 </p>
-              </div>
+              </Link>
             ))}
           </div>
         </GlassPane>

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -1,0 +1,44 @@
+export interface Service {
+  name: string;
+  description: string;
+  to: string;
+}
+
+export const services: Service[] = [
+  {
+    name: "SEO / SEA",
+    description:
+      "Zorg dat je gevonden wordt op Google, met AI-gestuurde zoekanalyse, slimme optimalisaties en gerichte campagnes.",
+    to: "/diensten/seo-sea",
+  },
+  {
+    name: "Data-gedreven Strategie",
+    description:
+      "Zet je data om in actie. Met duidelijke dashboards en inzichten bouwen we samen een strategie die werkt.",
+    to: "/diensten/data-gedreven-strategie",
+  },
+  {
+    name: "Webdesign",
+    description:
+      "Een frisse website die werkt op elk scherm. Visueel sterk, gebruiksvriendelijk en makkelijk aanpasbaar via een CMS.",
+    to: "/diensten/webdesign",
+  },
+  {
+    name: "Webdevelopment",
+    description:
+      "We bouwen schaalbare, performante webapplicaties op maat van jouw noden – met moderne technologie én een tikkeltje 'vibe coding'.",
+    to: "/diensten/webdevelopment",
+  },
+  {
+    name: "UI/UX",
+    description:
+      "Sterk design begint bij een fijne ervaring. We ontwerpen gebruiksvriendelijke interfaces met Figma die logisch aanvoelen én er goed uitzien.",
+    to: "/diensten/ui-ux",
+  },
+  {
+    name: "Lokale SEO",
+    description:
+      "Word beter zichtbaar in je regio met slimme, lokaal geoptimaliseerde landingspagina’s en vindbare content.",
+    to: "/diensten/lokale-seo",
+  },
+];

--- a/src/pages/DataStrategy.tsx
+++ b/src/pages/DataStrategy.tsx
@@ -1,0 +1,46 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const DataStrategy: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="Data-gedreven strategie | Xinudesign"
+        description="Zet je data om in actie met duidelijke dashboards en inzichten die je groei versnellen."
+        canonical="https://www.xinudesign.be/diensten/data-gedreven-strategie"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">
+          Data-gedreven strategie
+        </h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Zet je data om in actie. Met duidelijke dashboards en inzichten bouwen
+          we samen een strategie die werkt.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Heldere dashboards
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Actiegericht advies
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Strategie die rendeert
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default DataStrategy;

--- a/src/pages/LokaleSeo.tsx
+++ b/src/pages/LokaleSeo.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const LokaleSeo: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="Lokale SEO | Xinudesign"
+        description="Word beter zichtbaar in je regio met slimme, lokaal geoptimaliseerde landingspagina’s en vindbare content."
+        canonical="https://www.xinudesign.be/diensten/lokale-seo"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">Lokale SEO</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Word beter zichtbaar in je regio met slimme, lokaal geoptimaliseerde
+          landingspagina’s en vindbare content.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Lokaal geoptimaliseerde pagina’s
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Vindbare content
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Meer klanten in je regio
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default LokaleSeo;

--- a/src/pages/SeoSea.tsx
+++ b/src/pages/SeoSea.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const SeoSea: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="SEO & SEA | Xinudesign"
+        description="Scoor hoger in Google met AI-gestuurde zoekanalyse, slimme optimalisaties en gerichte campagnes."
+        canonical="https://www.xinudesign.be/diensten/seo-sea"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">SEO &amp; SEA</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Zorg dat je gevonden wordt op Google met AI-gestuurde zoekanalyse,
+          slimme optimalisaties en gerichte campagnes.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            AI-gestuurde zoekanalyse
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Slimme optimalisaties
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Gerichte campagnes
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default SeoSea;

--- a/src/pages/UiUx.tsx
+++ b/src/pages/UiUx.tsx
@@ -1,0 +1,45 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const UiUx: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="UI/UX design | Xinudesign"
+        description="Sterk design begint bij een fijne ervaring. We ontwerpen gebruiksvriendelijke interfaces met Figma die logisch aanvoelen én er goed uitzien."
+        canonical="https://www.xinudesign.be/diensten/ui-ux"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">UI/UX</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Sterk design begint bij een fijne ervaring. We ontwerpen
+          gebruiksvriendelijke interfaces met Figma die logisch aanvoelen én er
+          goed uitzien.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Figma prototypes
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Logische flows
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Pixel-perfect visuals
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default UiUx;

--- a/src/pages/Webdesign.tsx
+++ b/src/pages/Webdesign.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const Webdesign: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="Webdesign | Xinudesign"
+        description="Een frisse website die werkt op elk scherm. Visueel sterk, gebruiksvriendelijk en makkelijk aanpasbaar via een CMS."
+        canonical="https://www.xinudesign.be/diensten/webdesign"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">Webdesign</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          Een frisse website die werkt op elk scherm. Visueel sterk,
+          gebruiksvriendelijk en makkelijk aanpasbaar via een CMS.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Responsive design
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Visueel sterk
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            CMS dat je zelf beheert
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default Webdesign;

--- a/src/pages/Webdevelopment.tsx
+++ b/src/pages/Webdevelopment.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { FaCheckCircle } from "react-icons/fa";
+import Seo from "../components/Seo";
+
+const Webdevelopment: React.FC = () => {
+  return (
+    <>
+      <Seo
+        title="Webdevelopment | Xinudesign"
+        description="We bouwen schaalbare, performante webapplicaties op maat van jouw noden – met moderne technologie én een tikkeltje 'vibe coding'."
+        canonical="https://www.xinudesign.be/diensten/webdevelopment"
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24 text-center">
+        <h1 className="mb-6 text-4xl font-bold md:text-5xl">Webdevelopment</h1>
+        <p className="mb-8 text-lg text-gray-700">
+          We bouwen schaalbare, performante webapplicaties op maat van jouw
+          noden – met moderne technologie én een tikkeltje 'vibe coding'.
+        </p>
+        <ul className="mb-10 space-y-3 text-left">
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Moderne stack
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Schaalbaar &amp; performant
+          </li>
+          <li className="flex items-center gap-2">
+            <FaCheckCircle className="text-[#0362c8]" />
+            Vibe coding
+          </li>
+        </ul>
+        <Link
+          to="/contact"
+          className="inline-block rounded-xl bg-[#0362c8] px-8 py-3 font-medium text-white transition-colors hover:bg-[#024a96]"
+        >
+          Plan een gesprek
+        </Link>
+      </main>
+    </>
+  );
+};
+
+export default Webdevelopment;


### PR DESCRIPTION
## Summary
- centralize marketing service definitions
- link home page service cards to dedicated service pages
- add animated Services dropdown in header and expose links in mobile menu

## Testing
- `npm run format` (fails: Code style issues found in 7 files)
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_b_689c58e2a5bc83328e405bde80168110