### PR TITLE
chore: add keywords to service pages

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -225,6 +225,16 @@ export default function Contact() {
         title="Contact | Xinudesign"
         description="Contacteer Xinudesign (Michaël Redant) voor webdesign, SEO/SEA en datagedreven marketing. Samen groeien we digitaal."
         canonical="https://www.xinudesign.be/contact"
+        keywords={[
+          "contact",
+          "Xinudesign",
+          "webdesign",
+          "SEO",
+          "SEA",
+          "marketing",
+          "offerte",
+          "Herzele",
+        ]}
         // Meerdere JSON‑LD blokken toegestaan — Seo component moet dit als array doorzetten.
         jsonLd={jsonLdBundle}
       />

--- a/src/pages/Cv.tsx
+++ b/src/pages/Cv.tsx
@@ -121,6 +121,16 @@ export default function Cv() {
         title="Curriculum Vitae | Michaël Redant (Xinudesign)"
         description="Ik ben Michaël Redant: freelance webdeveloper & marketeer uit Borsbeke (Herzele). Sterk in SEO, data‑analyse en conversiegerichte websites. Bekijk mijn ervaring, skills en projecten."
         canonical="https://www.xinudesign.be/cv"
+        keywords={[
+          "curriculum vitae",
+          "Michaël Redant",
+          "freelance webdeveloper",
+          "marketeer",
+          "SEO specialist",
+          "data-analist",
+          "Borsbeke",
+          "ervaring",
+        ]}
         jsonLd={jsonLd}
       />
 

--- a/src/pages/DataStrategy.tsx
+++ b/src/pages/DataStrategy.tsx
@@ -9,6 +9,16 @@ const DataStrategy: React.FC = () => {
         title="Data Strategy & Dashboarding | Xinudesign"
         description="Bouw een schaalbare data-architectuur met datawarehouses, Power BI dashboards en geautomatiseerde ETL-processen via SSIS en SSMS. Van analyse tot implementatie."
         canonical="https://www.xinudesign.be/diensten/data-strategy"
+        keywords={[
+          "data strategy",
+          "dashboarding",
+          "datawarehouse",
+          "Power BI",
+          "ETL",
+          "SSIS",
+          "SSMS",
+          "business intelligence",
+        ]}
       />
 
       <main className="mx-auto max-w-6xl px-6 py-24">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -37,6 +37,16 @@ const Home: React.FC = () => {
         title="Webdevelopment & Marketing | Xinudesign"
         description="Freelance webdeveloper en marketeer voor kmo's in Vlaanderen. Websites die scoren in Google."
         canonical="https://www.xinudesign.be/"
+        keywords={[
+          "webdevelopment",
+          "marketing",
+          "freelance developer",
+          "SEO",
+          "SEA",
+          "webdesign",
+          "kmo",
+          "Vlaanderen",
+        ]}
         jsonLd={jsonLd}
       />
       <Hero />

--- a/src/pages/PersonaVault.tsx
+++ b/src/pages/PersonaVault.tsx
@@ -52,6 +52,16 @@ export default function PersonaVault() {
         title="Persona Vault | Xinudesign"
         description="Beheer AI-persona's en prompts centraal met de Persona Vault."
         canonical="https://www.xinudesign.be/persona-vault"
+        keywords={[
+          "Persona Vault",
+          "AI personas",
+          "prompt management",
+          "AI prompts",
+          "tagging",
+          "version control",
+          "workspace",
+          "collaboration",
+        ]}
       />
       <main className="px-4 py-24 bg-gradient-to-b from-white to-sky-50 dark:from-gray-900 dark:to-gray-800">
         {/* ───── Hero ───── */}

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -50,6 +50,16 @@ export default function Portfolio() {
         title="Portfolio Webdesign & Marketing | Xinudesign"
         description="Bekijk onze webdesign- en marketingprojecten in samenwerking met Pixapop. Professionele websites, SEO en online marketing voor kmo's in Vlaanderen."
         canonical="https://www.xinudesign.be/portfolio"
+        keywords={[
+          "portfolio",
+          "webdesign projecten",
+          "marketing cases",
+          "SEO realisaties",
+          "website voorbeelden",
+          "online marketing",
+          "kmo's",
+          "Pixapop",
+        ]}
       />
 
       <main className="bg-gradient-to-b from-white to-blue-50 dark:from-gray-900 dark:to-gray-800">


### PR DESCRIPTION
## Summary
- add SEO keyword arrays to data strategy, persona vault, home, portfolio, cv and contact pages

## Testing
- `npm run format` (fails: Code style issues found in 16 files)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a206c475d883328af9bec8b4bc364a