### PR TITLE
Improve blog pages with modern SaaS styling

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,5 +1,6 @@
 import matter from "gray-matter";
 import { Link } from "react-router-dom";
+import Seo from "../components/Seo";
 
 interface BlogMeta {
   title: string;
@@ -8,6 +9,7 @@ interface BlogMeta {
   excerpt: string;
   author?: string;
   tags?: string[];
+  image?: string;
 }
 
 export default function Blog() {
@@ -16,31 +18,94 @@ export default function Blog() {
     import: "default",
     eager: true,
   }) as Record<string, string>;
+  const posts: BlogMeta[] = Object.values(files)
+    .map((raw) => {
+      const { data } = matter(raw);
+      return data as BlogMeta;
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
-  const posts: BlogMeta[] = Object.values(files).map((raw) => {
-    const { data } = matter(raw);
-    return data as BlogMeta;
-  });
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    url: "https://www.xinudesign.be/blog",
+    name: "Xinudesign Blog",
+    description:
+      "Insights over webdesign, SEO en SaaS growth uit eigen studio.",
+    blogPost: posts.map((p) => ({
+      "@type": "BlogPosting",
+      headline: p.title,
+      url: `https://www.xinudesign.be/blog/${p.slug}`,
+      datePublished: p.date,
+    })),
+  };
 
   return (
-    <main className="max-w-6xl mx-auto px-6 py-20">
-      <h1 className="text-4xl font-bold mb-12">Blog</h1>
-      <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-        {posts.map((post) => (
-          <article
-            key={post.slug}
-            className="rounded-xl border p-6 hover:shadow-lg transition"
-          >
-            <h2 className="text-2xl font-semibold mb-2">
-              <Link to={`/blog/${post.slug}`}>{post.title}</Link>
-            </h2>
-            <p className="text-slate-600">{post.excerpt}</p>
-            <span className="block mt-3 text-sm text-slate-500">
-              {post.date}
-            </span>
-          </article>
-        ))}
-      </div>
-    </main>
+    <>
+      <Seo
+        title="Blog | Xinudesign"
+        description="Nieuwe inzichten over webdesign, marketing en AI."
+        canonical="https://www.xinudesign.be/blog"
+        keywords={["blog", "webdesign", "seo", "saas"]}
+        jsonLd={jsonLd}
+      />
+      <main className="px-4 py-24 bg-gradient-to-b from-white to-sky-50 dark:from-gray-900 dark:to-gray-800">
+        <section
+          className="max-w-6xl mx-auto text-center mb-16"
+          data-aos="fade-up"
+        >
+          <h1 className="text-5xl md:text-6xl font-extrabold text-slate-900 dark:text-white">
+            Blog
+          </h1>
+          <p className="mt-4 text-lg md:text-xl text-slate-600 dark:text-slate-300">
+            Verhalen, strategieën en tools voor digitale groei.
+          </p>
+        </section>
+        <section
+          className="grid gap-10 max-w-6xl mx-auto md:grid-cols-2 lg:grid-cols-3"
+          data-aos="fade-up"
+          data-aos-delay="100"
+        >
+          {posts.map((post) => (
+            <article
+              key={post.slug}
+              className="flex flex-col overflow-hidden rounded-2xl bg-white/70 dark:bg-slate-900/50 backdrop-blur border border-white/20 shadow-lg hover:shadow-xl transition"
+            >
+              {post.image && (
+                <img
+                  src={post.image}
+                  alt={post.title}
+                  className="h-48 w-full object-cover"
+                  loading="lazy"
+                />
+              )}
+              <div className="flex flex-col p-6 flex-1">
+                <h2 className="text-2xl font-semibold mb-2 text-slate-800 dark:text-slate-100">
+                  <Link to={`/blog/${post.slug}`}>{post.title}</Link>
+                </h2>
+                <p className="text-slate-600 dark:text-slate-300 flex-1">
+                  {post.excerpt}
+                </p>
+                <div className="mt-4 flex items-center justify-between text-sm text-slate-500 dark:text-slate-400">
+                  <span>{post.date}</span>
+                  {post.tags && (
+                    <span className="flex gap-2">
+                      {post.tags.slice(0, 2).map((tag) => (
+                        <span
+                          key={tag}
+                          className="px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300 text-xs"
+                        >
+                          #{tag}
+                        </span>
+                      ))}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </article>
+          ))}
+        </section>
+      </main>
+    </>
   );
 }

--- a/src/pages/BlogDetail.tsx
+++ b/src/pages/BlogDetail.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import matter from "gray-matter";
 import { marked } from "marked";
 import Seo from "../components/Seo"; // zelfde SEO-component die je al gebruikt
@@ -74,9 +74,24 @@ export default function BlogDetail() {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       itemListElement: [
-        { "@type": "ListItem", position: 1, name: "Home", item: "https://www.xinudesign.be/" },
-        { "@type": "ListItem", position: 2, name: "Blog", item: "https://www.xinudesign.be/blog" },
-        { "@type": "ListItem", position: 3, name: meta.title, item: canonicalUrl },
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Home",
+          item: "https://www.xinudesign.be/",
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Blog",
+          item: "https://www.xinudesign.be/blog",
+        },
+        {
+          "@type": "ListItem",
+          position: 3,
+          name: meta.title,
+          item: canonicalUrl,
+        },
       ],
     },
   ];
@@ -95,37 +110,50 @@ export default function BlogDetail() {
       />
 
       {/* 🔹 Blog content */}
-      <main className="max-w-4xl mx-auto px-6 py-20 prose dark:prose-invert">
-        <header className="mb-12">
-          <h1 className="text-4xl font-bold mb-2">{meta.title}</h1>
-          <p className="text-sm text-slate-500">
-            {meta.date} {meta.author && `• Geschreven door ${meta.author}`}
-          </p>
-          {meta.tags && (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {meta.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="px-3 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-700"
-                >
-                  #{tag}
-                </span>
-              ))}
-            </div>
-          )}
-          {meta.image && (
-            <img
-              src={meta.image}
-              alt={meta.title}
-              className="rounded-2xl shadow-lg mt-8"
-              loading="lazy"
-            />
-          )}
-        </header>
+      <main className="px-4 py-24 bg-gradient-to-b from-white to-sky-50 dark:from-gray-900 dark:to-gray-800">
+        <article className="mx-auto max-w-3xl">
+          <header className="mb-12 text-center">
+            <h1 className="text-4xl md:text-5xl font-extrabold mb-4 text-slate-900 dark:text-white">
+              {meta.title}
+            </h1>
+            <p className="text-sm text-slate-500">
+              {meta.date} {meta.author && `• Geschreven door ${meta.author}`}
+            </p>
+            {meta.tags && (
+              <div className="mt-4 flex flex-wrap justify-center gap-2">
+                {meta.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-3 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            )}
+            {meta.image && (
+              <img
+                src={meta.image}
+                alt={meta.title}
+                className="rounded-2xl shadow-lg mt-10 mx-auto"
+                loading="lazy"
+              />
+            )}
+          </header>
 
-        <article
-          dangerouslySetInnerHTML={{ __html: marked(post.content) }}
-        />
+          <div
+            className="prose dark:prose-invert max-w-none"
+            dangerouslySetInnerHTML={{ __html: marked(post.content) }}
+          />
+          <div className="mt-16 text-center">
+            <Link
+              to="/blog"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              ← Terug naar blog
+            </Link>
+          </div>
+        </article>
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- restyle blog overview with SaaS-inspired cards, hero, and SEO metadata
- refresh blog detail pages using gradient backgrounds, tag chips, and back links

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a212e7736c8332afcde67e52630a34