### PR TITLE
Expose blog across site navigation and pages

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -1,0 +1,113 @@
+import matter from "gray-matter";
+import { Link } from "react-router-dom";
+import { useMemo } from "react";
+
+interface BlogMeta {
+  title: string;
+  slug: string;
+  date: string;
+  excerpt?: string;
+  image?: string;
+  readingMinutes?: number;
+}
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString("nl-BE", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  });
+
+export default function BlogSection() {
+  const files = import.meta.glob("/src/content/blogs/*.md", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }) as Record<string, string>;
+
+  const posts = useMemo(
+    () =>
+      Object.values(files)
+        .map((raw) => {
+          const { data, content } = matter(raw);
+          const fm = data as BlogMeta;
+          const words = content.split(/\s+/).filter(Boolean);
+          const fallbackExcerpt =
+            fm.excerpt ||
+            words.slice(0, 24).join(" ") + (words.length > 24 ? "…" : "");
+          const reading =
+            fm.readingMinutes ||
+            Math.max(2, Math.round((words.length || 300) / 220));
+          return { ...fm, excerpt: fallbackExcerpt, readingMinutes: reading };
+        })
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+        .slice(0, 3),
+    [files],
+  );
+
+  return (
+    <section
+      className="px-4 py-24 bg-gradient-to-b from-white to-sky-50 dark:from-gray-900 dark:to-gray-800"
+      data-aos="fade-up"
+    >
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-3xl font-semibold text-center">Laatste artikels</h2>
+        <div className="mt-12 grid gap-8 md:grid-cols-3">
+          {posts.map((post) => {
+            const href = `/blog/${post.slug}`;
+            return (
+              <article
+                key={post.slug}
+                className="group flex flex-col overflow-hidden rounded-2xl bg-white/80 dark:bg-slate-900/60 backdrop-blur border border-white/40 dark:border-slate-800 shadow-[0_8px_30px_rgb(0,0,0,0.08)] hover:shadow-xl transition"
+              >
+                {post.image ? (
+                  <Link
+                    to={href}
+                    aria-label={post.title}
+                    className="relative block"
+                  >
+                    <img
+                      src={post.image}
+                      alt={post.title}
+                      loading="lazy"
+                      className="h-48 w-full object-cover aspect-[16/9] transition-transform duration-300 group-hover:scale-[1.02]"
+                    />
+                  </Link>
+                ) : (
+                  <div
+                    className="h-48 w-full bg-slate-100 dark:bg-slate-800"
+                    aria-hidden
+                  />
+                )}
+                <div className="flex flex-col p-6 flex-1">
+                  <h3 className="text-xl font-semibold mb-2 text-slate-900 dark:text-slate-100 leading-snug">
+                    <Link
+                      to={href}
+                      className="hover:underline decoration-2 underline-offset-2"
+                    >
+                      {post.title}
+                    </Link>
+                  </h3>
+                  <p className="text-slate-600 dark:text-slate-300 flex-1 line-clamp-3">
+                    {post.excerpt}
+                  </p>
+                  <div className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+                    {formatDate(post.date)} • {post.readingMinutes} min
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+        <div className="mt-12 text-center">
+          <Link
+            to="/blog"
+            className="inline-flex items-center gap-2 text-blue-700 dark:text-blue-300 font-medium hover:underline"
+          >
+            Alle artikels
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,7 @@ import { AnimatePresence, motion } from "framer-motion";
 const NAV = [
   { to: "/persona-vault", label: "Persona Vault" },
   { to: "/portfolio", label: "Portfolio" },
+  { to: "/blog", label: "Blog" },
   { to: "/cv", label: "Over mij" },
 ];
 
@@ -42,7 +43,10 @@ export default function Header() {
   };
   const closeServices = () => {
     if (servicesTimer.current) window.clearTimeout(servicesTimer.current);
-    servicesTimer.current = window.setTimeout(() => setServicesOpen(false), 100);
+    servicesTimer.current = window.setTimeout(
+      () => setServicesOpen(false),
+      100,
+    );
   };
 
   return (
@@ -55,7 +59,11 @@ export default function Header() {
     >
       <nav className="mx-auto flex h-full max-w-[1400px] items-center justify-between px-4 md:px-8">
         {/* Logo */}
-        <Link to="/" className="flex items-center gap-3 select-none h-full" aria-label="Ga naar home">
+        <Link
+          to="/"
+          className="flex items-center gap-3 select-none h-full"
+          aria-label="Ga naar home"
+        >
           <img
             src="/assets/xinu.webp"
             alt=""
@@ -159,7 +167,11 @@ export default function Header() {
           className="md:hidden p-2"
           onClick={() => setMenuOpen((s) => !s)}
         >
-          {menuOpen ? <FaTimes className="text-2xl text-slate-900" /> : <FaBars className="text-2xl text-slate-900" />}
+          {menuOpen ? (
+            <FaTimes className="text-2xl text-slate-900" />
+          ) : (
+            <FaBars className="text-2xl text-slate-900" />
+          )}
         </button>
       </nav>
 

--- a/src/pages/BlogDetail.tsx
+++ b/src/pages/BlogDetail.tsx
@@ -5,7 +5,6 @@ import { marked } from "marked";
 import Seo from "../components/Seo";
 import { FaLinkedin, FaTwitter, FaFacebook, FaLink } from "react-icons/fa";
 
-
 interface BlogMeta {
   title: string;
   slug: string;
@@ -46,9 +45,11 @@ const slugify = (input: unknown) =>
 
 /** ---------- marked configuratie (token API) ---------- */
 marked.setOptions({ mangle: false, headerIds: true, headerPrefix: "" });
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 (marked as any).use({
   renderer: {
     // In marked v8+ is het argument een token, niet "text, level"
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     heading(token: any) {
       const text = token?.text ?? token?.raw ?? "";
       const level = token?.depth ?? token?.level ?? 1;
@@ -79,16 +80,33 @@ export default function BlogDetail() {
     .filter((p) => p.meta?.date)
     .sort(
       (a, b) =>
-        new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime()
+        new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime(),
     );
 
   const currentIndex = sorted.findIndex((p) => p.meta.slug === slug);
   const current = sorted[currentIndex];
 
+  React.useEffect(() => {
+    const onScroll = () => {
+      const h = document.documentElement;
+      const scrolled = (h.scrollTop / (h.scrollHeight - h.clientHeight)) * 100;
+      h.style.setProperty("--scroll-progress", `${scrolled.toFixed(2)}%`);
+    };
+    onScroll();
+    document.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      document.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, []);
+
   if (!current) {
     return (
       <main className="px-4 py-24 max-w-3xl mx-auto">
-        <p className="text-slate-600 dark:text-slate-300">Artikel niet gevonden.</p>
+        <p className="text-slate-600 dark:text-slate-300">
+          Artikel niet gevonden.
+        </p>
         <Link
           to="/blog"
           className="text-blue-600 dark:text-blue-400 hover:underline mt-4 inline-block"
@@ -156,7 +174,12 @@ export default function BlogDetail() {
       itemListElement: [
         { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
         { "@type": "ListItem", position: 2, name: "Blog", item: blogUrl },
-        { "@type": "ListItem", position: 3, name: meta.title, item: canonicalUrl },
+        {
+          "@type": "ListItem",
+          position: 3,
+          name: meta.title,
+          item: canonicalUrl,
+        },
       ],
     },
   ];
@@ -164,26 +187,12 @@ export default function BlogDetail() {
   const prev = sorted[currentIndex + 1]?.meta;
   const next = sorted[currentIndex - 1]?.meta;
 
-  // Scroll-progress (CSS var)
-  React.useEffect(() => {
-    const onScroll = () => {
-      const h = document.documentElement;
-      const scrolled = (h.scrollTop / (h.scrollHeight - h.clientHeight)) * 100;
-      h.style.setProperty("--scroll-progress", `${scrolled.toFixed(2)}%`);
-    };
-    onScroll();
-    document.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("resize", onScroll);
-    return () => {
-      document.removeEventListener("scroll", onScroll);
-      window.removeEventListener("resize", onScroll);
-    };
-  }, []);
-
   const onCopy = async () => {
     try {
       await navigator.clipboard.writeText(canonicalUrl);
-    } catch {}
+    } catch {
+      // ignore
+    }
   };
 
   return (
@@ -197,7 +206,7 @@ export default function BlogDetail() {
         image={imageUrl}
         keywords={keywords ? keywords.split(",") : []}
         lastmod={meta.lastmod}
-         type="article"
+        type="article"
         publishedTime={meta.date}
         authorName={meta.author || "Xinudesign"}
       />
@@ -214,7 +223,8 @@ export default function BlogDetail() {
           {/* Hero */}
           <header className="mb-10 text-center" data-aos="fade-up">
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              {formatDate(meta.date)} • {readingMinutes} min {meta.author && `• ${meta.author}`}
+              {formatDate(meta.date)} • {readingMinutes} min{" "}
+              {meta.author && `• ${meta.author}`}
             </p>
             <h1 className="text-4xl md:text-5xl font-extrabold mt-3 tracking-tight text-slate-900 dark:text-white">
               {meta.title}
@@ -301,7 +311,7 @@ export default function BlogDetail() {
               <a
                 className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-700 hover:border-blue-400 text-sm"
                 href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
-                  canonicalUrl
+                  canonicalUrl,
                 )}`}
                 target="_blank"
                 rel="noreferrer"
@@ -311,7 +321,7 @@ export default function BlogDetail() {
               <a
                 className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-700 hover:border-blue-400 text-sm"
                 href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(
-                  canonicalUrl
+                  canonicalUrl,
                 )}&text=${encodeURIComponent(meta.title)}`}
                 target="_blank"
                 rel="noreferrer"
@@ -321,7 +331,7 @@ export default function BlogDetail() {
               <a
                 className="inline-flex items-center gap-2 px-3 py-2 rounded-xl border border-slate-200 dark:border-slate-700 hover:border-blue-400 text-sm"
                 href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
-                  canonicalUrl
+                  canonicalUrl,
                 )}`}
                 target="_blank"
                 rel="noreferrer"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import Intro from "../components/Intro";
 import NewSection from "../components/NewSection";
 import Specializations from "../components/Specializations";
 import ProjectSection from "../components/ProjectSection";
+import BlogSection from "../components/BlogSection";
 import Seo from "../components/Seo";
 
 const ToolsMarquee = lazy(() => import("../components/ToolsMarquee"));
@@ -60,6 +61,7 @@ const Home: React.FC = () => {
       </div>
       <NewSection />
       <Specializations />
+      <BlogSection />
       <ProjectSection />
     </>
   );

--- a/src/pages/LokaleSeoPage.tsx
+++ b/src/pages/LokaleSeoPage.tsx
@@ -11,6 +11,7 @@ import {
   FaQuoteRight,
 } from "react-icons/fa";
 import Seo from "../components/Seo";
+import BlogSection from "../components/BlogSection";
 
 const md = new MarkdownIt({ html: true, linkify: true });
 const mdFaq = new MarkdownIt({ html: true, linkify: true });
@@ -430,83 +431,85 @@ export default function LokaleSeoPage() {
         </motion.section>
 
         {/* =================== RELATED SERVICES LINKS =================== */}
-<motion.section
-  variants={stagger}
-  initial="hidden"
-  whileInView="show"
-  viewport={{ once: true, amount: 0.2 }}
-  className="mx-auto max-w-5xl px-4 sm:px-6 py-16"
->
-  <motion.h2
-    variants={reveal}
-    className="text-3xl font-bold mb-4 text-center"
-  >
-    Meer manieren om jouw online succes te boosten
-  </motion.h2>
-  <p className="text-center text-slate-600 dark:text-slate-300 max-w-2xl mx-auto mb-10">
-    Ontdek onze andere diensten die samen zorgen voor een sterke, meetbare en blijvende online aanwezigheid. 
-    Van vindbaarheid in Google tot een high-performance webapplicatie – wij maken het waar.
-  </p>
+        <motion.section
+          variants={stagger}
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.2 }}
+          className="mx-auto max-w-5xl px-4 sm:px-6 py-16"
+        >
+          <motion.h2
+            variants={reveal}
+            className="text-3xl font-bold mb-4 text-center"
+          >
+            Meer manieren om jouw online succes te boosten
+          </motion.h2>
+          <p className="text-center text-slate-600 dark:text-slate-300 max-w-2xl mx-auto mb-10">
+            Ontdek onze andere diensten die samen zorgen voor een sterke,
+            meetbare en blijvende online aanwezigheid. Van vindbaarheid in
+            Google tot een high-performance webapplicatie – wij maken het waar.
+          </p>
 
-  <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
-    {[
-      { 
-        name: "SEO / SEA", 
-        href: "/diensten/seo-sea", 
-        desc: "Scoor hoger in Google en zet bezoekers om in klanten.",
-        icon: FaChartLine 
-      },
-      { 
-        name: "Data-gedreven strategie", 
-        href: "/diensten/data-gedreven-strategie", 
-        desc: "Slimme beslissingen op basis van feiten, niet gevoel.",
-        icon: FaBullhorn 
-      },
-      { 
-        name: "Webdesign", 
-        href: "/diensten/webdesign", 
-        desc: "Professioneel design dat je merk laat schitteren.",
-        icon: FaCode 
-      },
-      { 
-        name: "Webdevelopment", 
-        href: "/diensten/webdevelopment", 
-        desc: "Maatwerk code voor maximale snelheid en flexibiliteit.",
-        icon: FaCode 
-      },
-      { 
-        name: "UI / UX", 
-        href: "/diensten/ui-ux", 
-        desc: "Een gebruikservaring die bezoekers laat converteren.",
-        icon: FaCheckCircle 
-      },
-      { 
-        name: "Lokale SEO", 
-        href: "/diensten/lokale-seo", 
-        desc: "Val op in jouw regio en trek meer klanten uit de buurt.",
-        icon: FaChartLine 
-      },
-    ].map((link) => (
-      <motion.a
-        key={link.name}
-        href={link.href}
-        variants={reveal}
-        whileHover={{ y: -4, scale: 1.03 }}
-        className="group rounded-2xl border border-slate-200 bg-white/80 p-6 text-center shadow-sm 
+          <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6">
+            {[
+              {
+                name: "SEO / SEA",
+                href: "/diensten/seo-sea",
+                desc: "Scoor hoger in Google en zet bezoekers om in klanten.",
+                icon: FaChartLine,
+              },
+              {
+                name: "Data-gedreven strategie",
+                href: "/diensten/data-gedreven-strategie",
+                desc: "Slimme beslissingen op basis van feiten, niet gevoel.",
+                icon: FaBullhorn,
+              },
+              {
+                name: "Webdesign",
+                href: "/diensten/webdesign",
+                desc: "Professioneel design dat je merk laat schitteren.",
+                icon: FaCode,
+              },
+              {
+                name: "Webdevelopment",
+                href: "/diensten/webdevelopment",
+                desc: "Maatwerk code voor maximale snelheid en flexibiliteit.",
+                icon: FaCode,
+              },
+              {
+                name: "UI / UX",
+                href: "/diensten/ui-ux",
+                desc: "Een gebruikservaring die bezoekers laat converteren.",
+                icon: FaCheckCircle,
+              },
+              {
+                name: "Lokale SEO",
+                href: "/diensten/lokale-seo",
+                desc: "Val op in jouw regio en trek meer klanten uit de buurt.",
+                icon: FaChartLine,
+              },
+            ].map((link) => (
+              <motion.a
+                key={link.name}
+                href={link.href}
+                variants={reveal}
+                whileHover={{ y: -4, scale: 1.03 }}
+                className="group rounded-2xl border border-slate-200 bg-white/80 p-6 text-center shadow-sm 
                    hover:shadow-lg hover:bg-gradient-to-b hover:from-blue-50 hover:to-white 
                    transition-all duration-300 dark:bg-slate-900/70 dark:border-slate-700 
                    dark:hover:from-slate-800 dark:hover:to-slate-900"
-      >
-        <div className="flex justify-center mb-4">
-          <link.icon className="h-8 w-8 text-blue-600 group-hover:text-blue-700 transition-colors" />
-        </div>
-        <h3 className="text-lg font-semibold">{link.name}</h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{link.desc}</p>
-      </motion.a>
-    ))}
-  </div>
-</motion.section>
-
+              >
+                <div className="flex justify-center mb-4">
+                  <link.icon className="h-8 w-8 text-blue-600 group-hover:text-blue-700 transition-colors" />
+                </div>
+                <h3 className="text-lg font-semibold">{link.name}</h3>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                  {link.desc}
+                </p>
+              </motion.a>
+            ))}
+          </div>
+        </motion.section>
 
         {/* MARKDOWN CONTENT: SaaS 2025 card + luxe prose */}
         <motion.section
@@ -552,137 +555,171 @@ export default function LokaleSeoPage() {
         </motion.section>
 
         {/* PERSONA VAULT – SaaS 2025 highlight */}
-<motion.section
-  initial={{ opacity: 0, y: 20 }}
-  whileInView={{ opacity: 1, y: 0 }}
-  viewport={{ once: true, amount: 0.25 }}
-  transition={{ duration: 0.6, ease: "easeOut" }}
-  className="relative m-20 overflow-hidden rounded-3xl border border-white/20 bg-white/70 p-6 sm:p-10 shadow-xl backdrop-blur-xl
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.25 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+          className="relative m-20 overflow-hidden rounded-3xl border border-white/20 bg-white/70 p-6 sm:p-10 shadow-xl backdrop-blur-xl
              dark:border-white/10 dark:bg-slate-900/50"
->
-  {/* decor: zachte blobs & hairline gradients */}
-  <span className="pointer-events-none absolute -top-16 -left-16 h-40 w-40 rounded-full bg-sky-500/20 blur-3xl" />
-  <span className="pointer-events-none absolute -bottom-16 -right-16 h-40 w-40 rounded-full bg-indigo-500/20 blur-3xl" />
-  <span className="pointer-events-none absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-sky-500/50 to-transparent" />
+        >
+          {/* decor: zachte blobs & hairline gradients */}
+          <span className="pointer-events-none absolute -top-16 -left-16 h-40 w-40 rounded-full bg-sky-500/20 blur-3xl" />
+          <span className="pointer-events-none absolute -bottom-16 -right-16 h-40 w-40 rounded-full bg-indigo-500/20 blur-3xl" />
+          <span className="pointer-events-none absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-sky-500/50 to-transparent" />
 
-  {/* kop + badge + lead */}
-  <div className="relative z-10 max-w-3xl">
-    <div className="inline-flex items-center gap-2 rounded-full border border-sky-300/40 bg-sky-50/70 px-3 py-1 text-xs font-semibold text-sky-700
-                    dark:border-sky-400/20 dark:bg-sky-400/10 dark:text-sky-300">
-      <span className="inline-block h-1.5 w-1.5 rounded-full bg-sky-500" />
-      Beta – Gratis uitproberen
-    </div>
+          {/* kop + badge + lead */}
+          <div className="relative z-10 max-w-3xl">
+            <div
+              className="inline-flex items-center gap-2 rounded-full border border-sky-300/40 bg-sky-50/70 px-3 py-1 text-xs font-semibold text-sky-700
+                    dark:border-sky-400/20 dark:bg-sky-400/10 dark:text-sky-300"
+            >
+              <span className="inline-block h-1.5 w-1.5 rounded-full bg-sky-500" />
+              Beta – Gratis uitproberen
+            </div>
 
-    <h2 className="mt-4 text-3xl md:text-4xl font-extrabold tracking-tight">
-      Persona Vault <span className="bg-gradient-to-r from-sky-500 to-indigo-500 bg-clip-text text-transparent">voor teams die met AI werken</span>
-    </h2>
+            <h2 className="mt-4 text-3xl md:text-4xl font-extrabold tracking-tight">
+              Persona Vault{" "}
+              <span className="bg-gradient-to-r from-sky-500 to-indigo-500 bg-clip-text text-transparent">
+                voor teams die met AI werken
+              </span>
+            </h2>
 
-    <p className="mt-4 text-slate-600 dark:text-slate-300 leading-relaxed">
-      Beheer <strong>AI‑persona’s</strong>, prompts en versies op één plek. Bouw bibliotheken,
-      werk samen in <strong>gedeelde workspaces</strong> en behoud controle met revisies &amp; visuele diff‑vergelijkingen.
-      Klaar voor groei met een <strong>API‑ready</strong> backend.
-    </p>
-  </div>
+            <p className="mt-4 text-slate-600 dark:text-slate-300 leading-relaxed">
+              Beheer <strong>AI‑persona’s</strong>, prompts en versies op één
+              plek. Bouw bibliotheken, werk samen in{" "}
+              <strong>gedeelde workspaces</strong> en behoud controle met
+              revisies &amp; visuele diff‑vergelijkingen. Klaar voor groei met
+              een <strong>API‑ready</strong> backend.
+            </p>
+          </div>
 
-  {/* content: features + mini mock / screenshot */}
-  <div className="relative z-10 mt-8 grid items-start gap-8 md:grid-cols-2">
-    {/* features */}
-    <div className="order-2 md:order-1">
-      <ul className="grid gap-3 sm:grid-cols-2">
-        {[
-          "Persona’s & prompts aanmaken en organiseren",
-          "Revisiegeschiedenis met side‑by‑side diff",
-          "Gedeelde workspaces voor teams & klanten",
-          "Collecties, tags en snelle zoekfilters",
-          "Rollen & permissies (team rights)",
-          "API‑ready voor toekomstige integraties",
-        ].map((feat) => (
-          <motion.li
-            key={feat}
-            whileHover={{ x: 4 }}
-            className="flex items-start gap-2 rounded-xl border border-white/30 bg-white/60 p-3 shadow-sm backdrop-blur
+          {/* content: features + mini mock / screenshot */}
+          <div className="relative z-10 mt-8 grid items-start gap-8 md:grid-cols-2">
+            {/* features */}
+            <div className="order-2 md:order-1">
+              <ul className="grid gap-3 sm:grid-cols-2">
+                {[
+                  "Persona’s & prompts aanmaken en organiseren",
+                  "Revisiegeschiedenis met side‑by‑side diff",
+                  "Gedeelde workspaces voor teams & klanten",
+                  "Collecties, tags en snelle zoekfilters",
+                  "Rollen & permissies (team rights)",
+                  "API‑ready voor toekomstige integraties",
+                ].map((feat) => (
+                  <motion.li
+                    key={feat}
+                    whileHover={{ x: 4 }}
+                    className="flex items-start gap-2 rounded-xl border border-white/30 bg-white/60 p-3 shadow-sm backdrop-blur
                        dark:border-white/10 dark:bg-white/5"
-          >
-            <FaCheckCircle className="mt-0.5 shrink-0 text-sky-500" />
-            <span className="text-sm text-slate-700 dark:text-slate-300">{feat}</span>
-          </motion.li>
-        ))}
-      </ul>
+                  >
+                    <FaCheckCircle className="mt-0.5 shrink-0 text-sky-500" />
+                    <span className="text-sm text-slate-700 dark:text-slate-300">
+                      {feat}
+                    </span>
+                  </motion.li>
+                ))}
+              </ul>
 
-      {/* CTA's */}
-      <div className="mt-6 flex flex-wrap items-center gap-3">
-        <a
-          href="/persona-vault"
-          className="inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold text-white
+              {/* CTA's */}
+              <div className="mt-6 flex flex-wrap items-center gap-3">
+                <a
+                  href="/persona-vault"
+                  className="inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold text-white
                      bg-gradient-to-r from-sky-600 to-indigo-600 shadow-lg ring-1 ring-white/10
                      hover:scale-[1.02] hover:shadow-xl transition-all"
-        >
-          Schrijf je gratis in
-        </a>
-        <a
-          href="/contact"
-          className="inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold
+                >
+                  Schrijf je gratis in
+                </a>
+                <a
+                  href="/contact"
+                  className="inline-flex items-center justify-center rounded-xl px-5 py-3 font-semibold
                      text-sky-800 bg-white/90 ring-1 ring-sky-200 hover:bg-white transition
                      dark:text-sky-200 dark:bg-white/5 dark:ring-white/10"
-        >
-          Meer info
-        </a>
-      </div>
-    </div>
+                >
+                  Meer info
+                </a>
+              </div>
+            </div>
 
-    {/* mini “screenshot” / mock – vervang evt. door echte afbeelding */}
-    <motion.div
-      className="order-1 md:order-2"
-      initial={{ opacity: 0, y: 10 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ duration: 0.5 }}
-    >
-      <div className="relative rounded-2xl border border-white/40 bg-white/80 p-3 shadow-xl backdrop-blur
-                      dark:border-white/10 dark:bg-slate-900/60">
-        {/* Titelbalk mock */}
-        <div className="flex items-center gap-2 rounded-lg bg-slate-100/80 p-2 dark:bg-white/5">
-          <span className="h-2.5 w-2.5 rounded-full bg-red-400" />
-          <span className="h-2.5 w-2.5 rounded-full bg-yellow-400" />
-          <span className="h-2.5 w-2.5 rounded-full bg-green-400" />
-          <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">Persona Vault – Workspace</span>
-        </div>
-
-        {/* Body mock (cards + diff) */}
-        <div className="mt-3 grid gap-3 md:grid-cols-2">
-          <div className="rounded-xl border border-slate-200/60 bg-white/70 p-3 shadow-sm
-                          dark:border-white/10 dark:bg-white/5">
-            <div className="text-xs font-semibold text-slate-500 dark:text-slate-400">Persona’s</div>
-            <div className="mt-2 grid grid-cols-2 gap-2">
-              {["Support Bot", "Sales Coach", "UX Writer", "Dev Tutor"].map((p) => (
-                <div key={p} className="rounded-lg border border-slate-200/60 bg-white/80 p-2 text-xs
-                                        dark:border-white/10 dark:bg-white/5">
-                  {p}
+            {/* mini “screenshot” / mock – vervang evt. door echte afbeelding */}
+            <motion.div
+              className="order-1 md:order-2"
+              initial={{ opacity: 0, y: 10 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5 }}
+            >
+              <div
+                className="relative rounded-2xl border border-white/40 bg-white/80 p-3 shadow-xl backdrop-blur
+                      dark:border-white/10 dark:bg-slate-900/60"
+              >
+                {/* Titelbalk mock */}
+                <div className="flex items-center gap-2 rounded-lg bg-slate-100/80 p-2 dark:bg-white/5">
+                  <span className="h-2.5 w-2.5 rounded-full bg-red-400" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-yellow-400" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-green-400" />
+                  <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
+                    Persona Vault – Workspace
+                  </span>
                 </div>
-              ))}
-            </div>
-          </div>
-          <div className="rounded-xl border border-slate-200/60 bg-white/70 p-3 shadow-sm
-                          dark:border-white/10 dark:bg-white/5">
-            <div className="text-xs font-semibold text-slate-500 dark:text-slate-400">Diff‑vergelijking</div>
-            <div className="mt-2 grid grid-cols-2 gap-2 text-[10px] leading-relaxed">
-              <div className="rounded-lg bg-rose-50/80 p-2 text-rose-700 dark:bg-rose-400/10 dark:text-rose-300">
-                – “Tone: formal”<br />– “Max length: 200”
+
+                {/* Body mock (cards + diff) */}
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <div
+                    className="rounded-xl border border-slate-200/60 bg-white/70 p-3 shadow-sm
+                          dark:border-white/10 dark:bg-white/5"
+                  >
+                    <div className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      Persona’s
+                    </div>
+                    <div className="mt-2 grid grid-cols-2 gap-2">
+                      {[
+                        "Support Bot",
+                        "Sales Coach",
+                        "UX Writer",
+                        "Dev Tutor",
+                      ].map((p) => (
+                        <div
+                          key={p}
+                          className="rounded-lg border border-slate-200/60 bg-white/80 p-2 text-xs
+                                        dark:border-white/10 dark:bg-white/5"
+                        >
+                          {p}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div
+                    className="rounded-xl border border-slate-200/60 bg-white/70 p-3 shadow-sm
+                          dark:border-white/10 dark:bg-white/5"
+                  >
+                    <div className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      Diff‑vergelijking
+                    </div>
+                    <div className="mt-2 grid grid-cols-2 gap-2 text-[10px] leading-relaxed">
+                      <div className="rounded-lg bg-rose-50/80 p-2 text-rose-700 dark:bg-rose-400/10 dark:text-rose-300">
+                        – “Tone: formal”
+                        <br />– “Max length: 200”
+                      </div>
+                      <div className="rounded-lg bg-emerald-50/80 p-2 text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-300">
+                        + “Tone: friendly”
+                        <br />+ “Max length: 160”
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div className="rounded-lg bg-emerald-50/80 p-2 text-emerald-700 dark:bg-emerald-400/10 dark:text-emerald-300">
-                + “Tone: friendly”<br />+ “Max length: 160”
-              </div>
-            </div>
+              {/* ondertitel */}
+              <p className="mt-2 text-center text-xs text-slate-500 dark:text-slate-400">
+                App nog in beta – schrijf je in voor gratis toegang en updates!
+              </p>
+            </motion.div>
           </div>
-        </div>
-      </div>
-      {/* ondertitel */}
-      <p className="mt-2 text-center text-xs text-slate-500 dark:text-slate-400">
-        App nog in beta – schrijf je in voor gratis toegang en updates!
-      </p>
-    </motion.div>
-  </div>
-</motion.section>
+        </motion.section>
+
+        {/* Blog artikels */}
+        <BlogSection />
 
         {/* =================== FAQ =================== */}
         {fm.faqs?.length ? (


### PR DESCRIPTION
## Summary
- add blog link to main navigation
- surface latest articles via reusable BlogSection component
- display blog teasers on home and local SEO landing pages
- clean up blog detail page for lint compliance

## Testing
- `npm run format` (fails: Code style issues found in 25 files)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a24cda32248332b97b1b4a05ed5b1e